### PR TITLE
Value partition

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,4 +14,5 @@ const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .allow_division_by_zero = true,
     .setup_constraints = true,
     .big_endian = false,
+    .use_value_partitioning = true,
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,5 +14,4 @@ const ebpf_verifier_options_t ebpf_verifier_default_options = {
     .allow_division_by_zero = true,
     .setup_constraints = true,
     .big_endian = false,
-    .use_value_partitioning = true,
 };

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <string>
+#include <vector>
+
 struct ebpf_verifier_options_t {
     bool check_termination;
     bool assume_assertions;
@@ -21,7 +24,7 @@ struct ebpf_verifier_options_t {
     bool big_endian;
 
     bool dump_btf_types_json;
-    bool use_value_partitioning;
+    std::vector<std::string> partition_keys;
 };
 
 struct ebpf_verifier_stats_t {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -21,6 +21,7 @@ struct ebpf_verifier_options_t {
     bool big_endian;
 
     bool dump_btf_types_json;
+    bool use_value_partitioning;
 };
 
 struct ebpf_verifier_stats_t {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <map>
 
 struct ebpf_verifier_options_t {
     bool check_termination;
@@ -24,7 +24,7 @@ struct ebpf_verifier_options_t {
     bool big_endian;
 
     bool dump_btf_types_json;
-    std::vector<std::string> partition_keys;
+    std::map<std::string, std::string> label_to_partition_key;
 };
 
 struct ebpf_verifier_stats_t {

--- a/src/crab/ebpf_domain.cpp
+++ b/src/crab/ebpf_domain.cpp
@@ -812,7 +812,7 @@ bool ebpf_domain_t::is_bottom() const { return m_inv.is_bottom(); }
 
 bool ebpf_domain_t::is_top() const { return m_inv.is_top() && stack.is_top(); }
 
-bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) { return m_inv <= other.m_inv && stack <= other.stack; }
+bool ebpf_domain_t::operator<=(const ebpf_domain_t& other) const { return m_inv <= other.m_inv && stack <= other.stack; }
 
 bool ebpf_domain_t::operator==(const ebpf_domain_t& other) const {
     return stack == other.stack && m_inv <= other.m_inv && other.m_inv <= m_inv;
@@ -945,14 +945,14 @@ ebpf_domain_t ebpf_domain_t::calculate_constant_limits() {
 
 static const ebpf_domain_t constant_limits = ebpf_domain_t::calculate_constant_limits();
 
-ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other, bool to_constants) {
+ebpf_domain_t ebpf_domain_t::widen(const ebpf_domain_t& other, bool to_constants) const {
     ebpf_domain_t res{m_inv.widen(other.m_inv), stack | other.stack};
     if (to_constants)
         return res & constant_limits;
     return res;
 }
 
-ebpf_domain_t ebpf_domain_t::narrow(const ebpf_domain_t& other) {
+ebpf_domain_t ebpf_domain_t::narrow(const ebpf_domain_t& other) const {
     return ebpf_domain_t(m_inv.narrow(other.m_inv), stack & other.stack);
 }
 

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -35,7 +35,7 @@ class ebpf_domain_t final {
     void set_to_bottom();
     [[nodiscard]] bool is_bottom() const;
     [[nodiscard]] bool is_top() const;
-    bool operator<=(const ebpf_domain_t& other);
+    bool operator<=(const ebpf_domain_t& other) const;
     bool operator==(const ebpf_domain_t& other) const;
     void operator|=(ebpf_domain_t&& other);
     void operator|=(const ebpf_domain_t& other);
@@ -43,9 +43,9 @@ class ebpf_domain_t final {
     ebpf_domain_t operator|(const ebpf_domain_t& other) const&;
     ebpf_domain_t operator|(const ebpf_domain_t& other) &&;
     ebpf_domain_t operator&(const ebpf_domain_t& other) const;
-    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants);
-    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts);
-    ebpf_domain_t narrow(const ebpf_domain_t& other);
+    ebpf_domain_t widen(const ebpf_domain_t& other, bool to_constants) const;
+    ebpf_domain_t widening_thresholds(const ebpf_domain_t& other, const crab::iterators::thresholds_t& ts) const;
+    ebpf_domain_t narrow(const ebpf_domain_t& other) const;
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -19,7 +19,7 @@ using NumAbsDomain = domains::NumAbsDomain;
 
 struct reg_pack_t;
 
-class ebpf_domain_t final {
+class ebpf_domain_t {
     struct TypeDomain;
 
     friend class ebpf_value_partition_domain_t;

--- a/src/crab/ebpf_domain.hpp
+++ b/src/crab/ebpf_domain.hpp
@@ -22,6 +22,8 @@ struct reg_pack_t;
 class ebpf_domain_t final {
     struct TypeDomain;
 
+    friend class ebpf_value_partition_domain_t;
+
   public:
     ebpf_domain_t();
     ebpf_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);

--- a/src/crab/ebpf_value_partition_domain.cpp
+++ b/src/crab/ebpf_value_partition_domain.cpp
@@ -24,82 +24,78 @@
 namespace crab {
 
 ebpf_value_partition_domain_t::ebpf_value_partition_domain_t() : partitions(1) {}
-ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack) :
-    partitions {{std::move(inv), stack}} {}
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(crab::domains::NumAbsDomain inv,
+                                                             crab::domains::array_domain_t stack)
+    : partitions{{std::move(inv), stack}} {}
 
-ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain) : partitions(1, std::move(ebpf_domain)) {}
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain)
+    : partitions(1, std::move(ebpf_domain)) {}
+
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(std::vector<ebpf_domain_t>&& partitions)
+    : partitions(std::move(partitions)) {}
 
 // Generic abstract domain operations
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::top()
-{
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::top() {
     ebpf_value_partition_domain_t abs;
     abs.set_to_top();
     return abs;
 }
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::bottom()
-{
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::bottom() {
     ebpf_value_partition_domain_t abs;
     abs.set_to_bottom();
     return abs;
 }
-void ebpf_value_partition_domain_t::set_to_top()
-{
+void ebpf_value_partition_domain_t::set_to_top() {
     partitions.resize(1);
     partitions[0].set_to_top();
 }
-void ebpf_value_partition_domain_t::set_to_bottom()
-{
+void ebpf_value_partition_domain_t::set_to_bottom() {
     partitions.resize(1);
     partitions[0].set_to_bottom();
 }
-[[nodiscard]] bool ebpf_value_partition_domain_t::is_bottom() const
-{
-    return std::all_of(partitions.begin(), partitions.end(), [](const auto& partition) { return partition.is_bottom(); });
+[[nodiscard]]
+bool ebpf_value_partition_domain_t::is_bottom() const {
+    return std::all_of(partitions.begin(), partitions.end(),
+                       [](const auto& partition) { return partition.is_bottom(); });
 }
-[[nodiscard]] bool ebpf_value_partition_domain_t::is_top() const
-{
+[[nodiscard]]
+bool ebpf_value_partition_domain_t::is_top() const {
     return std::all_of(partitions.begin(), partitions.end(), [](const auto& partition) { return partition.is_top(); });
 }
-bool ebpf_value_partition_domain_t::operator<=(const ebpf_value_partition_domain_t& other) {
-    ebpf_value_partition_domain_t lhs = *this;
-    ebpf_value_partition_domain_t rhs = other;
-    lhs.merge_all_partitions();
-    rhs.merge_all_partitions();
+bool ebpf_value_partition_domain_t::operator<=(const ebpf_value_partition_domain_t& other) const {
 
-    return lhs.partitions[0] <= rhs.partitions[0];
-    //return std::all_of(partitions.begin(), partitions.end(), [&other](auto& partition) {
-    //    return std::any_of(other.partitions.begin(), other.partitions.end(), [&partition](const auto& other_partition) {
-    //        return partition <= other_partition;
-    //    });
-    //});
+    bool return_value = true;
+    merge_or_apply_to_all_partitions(
+        other, [&return_value](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) { return_value &= lhs <= rhs; });
+
+    return return_value;
 }
-bool ebpf_value_partition_domain_t::operator==(const ebpf_value_partition_domain_t& other) const
-{
-    return partitions == other.partitions;
+bool ebpf_value_partition_domain_t::operator==(const ebpf_value_partition_domain_t& other) const {
+    bool return_value = true;
+    merge_or_apply_to_all_partitions(
+        other, [&return_value](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) { return_value &= lhs == rhs; });
+
+    return return_value;
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::join(const ebpf_value_partition_domain_t& lhs, const ebpf_value_partition_domain_t& rhs)
-{
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::join(const ebpf_value_partition_domain_t& lhs,
+                                                                  const ebpf_value_partition_domain_t& rhs) {
     std::vector<ebpf_domain_t> partitions;
 
     // Check if any partitions have a value for the packet size.
     bool has_packet_size = false;
-    for (const auto& partition : lhs.partitions)
-    {
+    for (const auto& partition : lhs.partitions) {
         if (!partition.is_bottom() && !partition.m_inv[variable_t::packet_size()].is_bottom() &&
-            !partition.m_inv[variable_t::packet_size()].is_top())
-        {
+            !partition.m_inv[variable_t::packet_size()].is_top()) {
             auto interval = partition.m_inv[variable_t::packet_size()];
             has_packet_size = true;
             break;
         }
     }
 
-    for (const auto& partition : rhs.partitions)
-    {
+    for (const auto& partition : rhs.partitions) {
         if (!partition.is_bottom() && !partition.m_inv[variable_t::packet_size()].is_bottom() &&
-            !partition.m_inv[variable_t::packet_size()].is_top())
-        {
+            !partition.m_inv[variable_t::packet_size()].is_top()) {
             auto interval = partition.m_inv[variable_t::packet_size()];
             has_packet_size = true;
             break;
@@ -107,16 +103,13 @@ ebpf_value_partition_domain_t ebpf_value_partition_domain_t::join(const ebpf_val
     }
 
     // If no partitions have a value for the packet size, just merge all partitions.
-    if (!has_packet_size)
-    {
+    if (!has_packet_size) {
         ebpf_domain_t res_domain;
         res_domain.set_to_bottom();
-        for (const auto& lhs_partition : lhs.partitions)
-        {
+        for (const auto& lhs_partition : lhs.partitions) {
             res_domain |= lhs_partition;
         }
-        for (const auto& rhs_partition : rhs.partitions)
-        {
+        for (const auto& rhs_partition : rhs.partitions) {
             res_domain |= rhs_partition;
         }
         partitions.push_back(res_domain);
@@ -126,69 +119,52 @@ ebpf_value_partition_domain_t ebpf_value_partition_domain_t::join(const ebpf_val
         return res;
     }
 
-
     // Copy all non-bottom partitions from the left-hand side.
-    for (const auto& lhs_partition : lhs.partitions)
-    {
-       if (!lhs_partition.is_bottom())
-       {
-           partitions.push_back(lhs_partition);
-       }
+    for (const auto& lhs_partition : lhs.partitions) {
+        if (!lhs_partition.is_bottom()) {
+            partitions.push_back(lhs_partition);
+        }
     }
 
     // Copy all non-bottom partitions from the right-hand side.
-    for (const auto& rhs_partition : rhs.partitions)
-    {
-       if (!rhs_partition.is_bottom())
-       {
-           partitions.push_back(rhs_partition);
-       }
+    for (const auto& rhs_partition : rhs.partitions) {
+        if (!rhs_partition.is_bottom()) {
+            partitions.push_back(rhs_partition);
+        }
     }
-
 
     // Sort the partitions by the packet size interval.
     std::sort(partitions.begin(), partitions.end(), [](const auto& lhs, const auto& rhs) {
-       auto lhs_interval = lhs.m_inv[variable_t::packet_size()];
-       auto rhs_interval = rhs.m_inv[variable_t::packet_size()];
+        auto lhs_interval = lhs.m_inv[variable_t::packet_size()];
+        auto rhs_interval = rhs.m_inv[variable_t::packet_size()];
 
-       if (lhs_interval.is_bottom())
-       {
-           return false;
-       }
-       if (rhs_interval.is_bottom())
-       {
-           return true;
-       }
+        if (lhs_interval.is_bottom()) {
+            return false;
+        }
+        if (rhs_interval.is_bottom()) {
+            return true;
+        }
 
-       if (lhs_interval.lb() < rhs_interval.lb())
-       {
-           return true;
-       } else if (lhs_interval.lb() > rhs_interval.lb())
-       {
-           return false;
-       }
-       else
-       {
-           return lhs_interval.ub() < rhs_interval.ub();
-       }
+        if (lhs_interval.lb() < rhs_interval.lb()) {
+            return true;
+        } else if (lhs_interval.lb() > rhs_interval.lb()) {
+            return false;
+        } else {
+            return lhs_interval.ub() < rhs_interval.ub();
+        }
     });
 
     // Merge partitions that have the same packet size interval.
-    for (size_t i = 0; i < partitions.size(); i++)
-    {
-       for (size_t j = i + 1; j < partitions.size(); j++)
-       {
-           if (partitions[i].m_inv[variable_t::packet_size()] == partitions[j].m_inv[variable_t::packet_size()])
-           {
-               partitions[i] |= partitions[j];
-               partitions.erase(partitions.begin() + j);
-               j--;
-           }
-           else
-           {
-               break;
-           }
-       }
+    for (size_t i = 0; i < partitions.size(); i++) {
+        for (size_t j = i + 1; j < partitions.size(); j++) {
+            if (partitions[i].m_inv[variable_t::packet_size()] == partitions[j].m_inv[variable_t::packet_size()]) {
+                partitions[i] |= partitions[j];
+                partitions.erase(partitions.begin() + j);
+                j--;
+            } else {
+                break;
+            }
+        }
     }
 
     ebpf_value_partition_domain_t res;
@@ -210,7 +186,8 @@ ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(ebpf_valu
     return join(*this, std::move(other));
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) const& {
+ebpf_value_partition_domain_t
+ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) const& {
     return join(*this, other);
 }
 
@@ -218,99 +195,77 @@ ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebp
     return std::move(join(*this, other));
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator&(const ebpf_value_partition_domain_t& other) const
-{
-    ebpf_value_partition_domain_t lhs = *this;
-    ebpf_value_partition_domain_t rhs = other;
-    ebpf_value_partition_domain_t res;
+ebpf_value_partition_domain_t
+ebpf_value_partition_domain_t::operator&(const ebpf_value_partition_domain_t& other) const {
+    std::vector<ebpf_domain_t> partitions;
 
-    lhs.merge_all_partitions();
-    rhs.merge_all_partitions();
+    merge_or_apply_to_all_partitions(
+        other, [&partitions](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) { partitions.push_back(lhs & rhs); });
 
-    res.partitions[0] = lhs.partitions[0] & rhs.partitions[0];
-
-    return res;
+    return std::move(partitions);
 }
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::widen(const ebpf_value_partition_domain_t& other, bool to_constants)
-{
-    ebpf_value_partition_domain_t lhs = *this;
-    ebpf_value_partition_domain_t rhs = other;
-    ebpf_value_partition_domain_t res;
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::widen(const ebpf_value_partition_domain_t& other,
+                                                                   bool to_constants) {
+    std::vector<ebpf_domain_t> partitions;
+    merge_or_apply_to_all_partitions(other,
+                                     [&partitions, to_constants](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) {
+                                         partitions.push_back(lhs.widen(rhs, to_constants));
+                                     });
 
-    lhs.merge_all_partitions();
-    rhs.merge_all_partitions();
-
-    res.partitions[0] = lhs.partitions[0].widen(rhs.partitions[0], to_constants);
-
-    return res;
+    return std::move(partitions);
 }
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::narrow(const ebpf_value_partition_domain_t& other)
-{
-    ebpf_value_partition_domain_t lhs = *this;
-    ebpf_value_partition_domain_t rhs = other;
-    ebpf_value_partition_domain_t res;
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::narrow(const ebpf_value_partition_domain_t& other) {
+    std::vector<ebpf_domain_t> partitions;
+    merge_or_apply_to_all_partitions(other, [&partitions](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) {
+        partitions.push_back(lhs.narrow(rhs));
+    });
 
-    lhs.merge_all_partitions();
-    rhs.merge_all_partitions();
-
-    res.partitions[0] = lhs.partitions[0].narrow(rhs.partitions[0]);
-
-    return res;
+    return std::move(partitions);
 }
 
-void ebpf_value_partition_domain_t::set_require_check(std::function<check_require_func_t> f)
-{
+void ebpf_value_partition_domain_t::set_require_check(std::function<check_require_func_t> f) {
     merge_all_partitions();
-    for (auto& partition : partitions)
-    {
+    for (auto& partition : partitions) {
         partition.set_require_check(f);
     }
 }
-bound_t ebpf_value_partition_domain_t::get_loop_count_upper_bound()
-{
+bound_t ebpf_value_partition_domain_t::get_loop_count_upper_bound() {
     merge_all_partitions();
     bound_t ub{number_t{0}};
-    for (auto& partition : partitions)
-    {
+    for (auto& partition : partitions) {
         ub = std::max(ub, partition.get_loop_count_upper_bound());
     }
     return ub;
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::setup_entry(bool init_r1)
-{
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::setup_entry(bool init_r1) {
     ebpf_value_partition_domain_t abs;
     abs.partitions[0] = ebpf_domain_t::setup_entry(init_r1);
     return abs;
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::from_constraints(const std::set<std::string>& constraints, bool setup_constraints)
-{
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::from_constraints(const std::set<std::string>& constraints,
+                                                                              bool setup_constraints) {
     ebpf_value_partition_domain_t abs;
     abs.partitions[0] = ebpf_domain_t::from_constraints(constraints, setup_constraints);
     return abs;
 }
 
-string_invariant ebpf_value_partition_domain_t::to_set()
-{
+string_invariant ebpf_value_partition_domain_t::to_set() {
     ebpf_value_partition_domain_t tmp = *this;
     tmp.merge_all_partitions();
     return tmp.partitions[0].to_set();
 }
 
-// abstract transformers
-
-void ebpf_value_partition_domain_t::initialize_loop_counter(label_t label)
-{
+void ebpf_value_partition_domain_t::initialize_loop_counter(label_t label) {
     merge_all_partitions();
 
-    for (auto& partition : partitions)
-    {
+    for (auto& partition : partitions) {
         partition.initialize_loop_counter(label);
     }
 }
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::calculate_constant_limits()
-{
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::calculate_constant_limits() {
     ebpf_value_partition_domain_t abs;
     abs.partitions[0] = ebpf_domain_t::calculate_constant_limits();
     return abs;
@@ -323,23 +278,48 @@ std::ostream& operator<<(std::ostream& o, const ebpf_value_partition_domain_t& d
     return o;
 }
 
-void ebpf_value_partition_domain_t::merge_all_partitions()
-{
-    if (partitions.size() == 0)
-    {
+void ebpf_value_partition_domain_t::merge_all_partitions() {
+    if (partitions.size() == 0) {
         set_to_bottom();
-    }
-    else if (partitions.size() == 1)
-    {
+    } else if (partitions.size() == 1) {
         // Nothing to do.
-    }
-    else {
+    } else {
         // Merge all partitions into the first one.
-        for (size_t i = 1; i < partitions.size(); i++)
-        {
+        for (size_t i = 1; i < partitions.size(); i++) {
             partitions[0] |= partitions[i];
         }
         partitions.resize(1);
+    }
+}
+
+bool ebpf_value_partition_domain_t::has_same_partitions(const ebpf_value_partition_domain_t& other) const {
+    if (partitions.size() != other.partitions.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < partitions.size(); i++) {
+        if (partitions[i].m_inv[variable_t::packet_size()] != other.partitions[i].m_inv[variable_t::packet_size()]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void ebpf_value_partition_domain_t::merge_or_apply_to_all_partitions(
+    const ebpf_value_partition_domain_t& other,
+    std::function<void(const ebpf_domain_t&, const ebpf_domain_t&)> f) const {
+    if (!has_same_partitions(other)) {
+        ebpf_value_partition_domain_t lhs = *this;
+        ebpf_value_partition_domain_t rhs = other;
+        lhs.merge_all_partitions();
+        rhs.merge_all_partitions();
+
+        f(lhs.partitions[0], rhs.partitions[0]);
+    } else {
+        for (size_t i = 0; i < partitions.size(); i++) {
+            f(partitions[i], other.partitions[i]);
+        }
     }
 }
 

--- a/src/crab/ebpf_value_partition_domain.cpp
+++ b/src/crab/ebpf_value_partition_domain.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+
+// This file is eBPF-specific, not derived from CRAB.
+
+#include <bitset>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "boost/endian/conversion.hpp"
+#include "boost/range/algorithm/set_algorithm.hpp"
+
+#include "crab/array_domain.hpp"
+#include "crab/ebpf_value_partition_domain.hpp"
+
+#include "asm_ostream.hpp"
+#include "asm_unmarshal.hpp"
+#include "config.hpp"
+#include "dsl_syntax.hpp"
+#include "platform.hpp"
+#include "string_constraints.hpp"
+
+namespace crab {
+
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t() : partitions(1) {}
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack) :
+    partitions {{std::move(inv), stack}} {}
+
+ebpf_value_partition_domain_t::ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain) : partitions(1, std::move(ebpf_domain)) {}
+
+// Generic abstract domain operations
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::top()
+{
+    ebpf_value_partition_domain_t abs;
+    abs.set_to_top();
+    return abs;
+}
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::bottom()
+{
+    ebpf_value_partition_domain_t abs;
+    abs.set_to_bottom();
+    return abs;
+}
+void ebpf_value_partition_domain_t::set_to_top()
+{
+    partitions.resize(1);
+    partitions[0].set_to_top();
+}
+void ebpf_value_partition_domain_t::set_to_bottom()
+{
+    partitions.resize(1);
+    partitions[0].set_to_bottom();
+}
+[[nodiscard]] bool ebpf_value_partition_domain_t::is_bottom() const
+{
+    return std::all_of(partitions.begin(), partitions.end(), [](const auto& partition) { return partition.is_bottom(); });
+}
+[[nodiscard]] bool ebpf_value_partition_domain_t::is_top() const
+{
+    return std::all_of(partitions.begin(), partitions.end(), [](const auto& partition) { return partition.is_top(); });
+}
+bool ebpf_value_partition_domain_t::operator<=(const ebpf_value_partition_domain_t& other) {
+    ebpf_value_partition_domain_t lhs = *this;
+    ebpf_value_partition_domain_t rhs = other;
+    lhs.merge_all_partitions();
+    rhs.merge_all_partitions();
+
+    return lhs.partitions[0] <= rhs.partitions[0];
+    //return std::all_of(partitions.begin(), partitions.end(), [&other](auto& partition) {
+    //    return std::any_of(other.partitions.begin(), other.partitions.end(), [&partition](const auto& other_partition) {
+    //        return partition <= other_partition;
+    //    });
+    //});
+}
+bool ebpf_value_partition_domain_t::operator==(const ebpf_value_partition_domain_t& other) const
+{
+    return partitions == other.partitions;
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::join(const ebpf_value_partition_domain_t& lhs, const ebpf_value_partition_domain_t& rhs)
+{
+    std::vector<ebpf_domain_t> partitions;
+
+    // Check if any partitions have a value for the packet size.
+    bool has_packet_size = false;
+    for (const auto& partition : lhs.partitions)
+    {
+        if (!partition.is_bottom() && !partition.m_inv[variable_t::packet_size()].is_bottom() &&
+            !partition.m_inv[variable_t::packet_size()].is_top())
+        {
+            auto interval = partition.m_inv[variable_t::packet_size()];
+            has_packet_size = true;
+            break;
+        }
+    }
+
+    for (const auto& partition : rhs.partitions)
+    {
+        if (!partition.is_bottom() && !partition.m_inv[variable_t::packet_size()].is_bottom() &&
+            !partition.m_inv[variable_t::packet_size()].is_top())
+        {
+            auto interval = partition.m_inv[variable_t::packet_size()];
+            has_packet_size = true;
+            break;
+        }
+    }
+
+    // If no partitions have a value for the packet size, just merge all partitions.
+    if (!has_packet_size)
+    {
+        ebpf_domain_t res_domain;
+        res_domain.set_to_bottom();
+        for (const auto& lhs_partition : lhs.partitions)
+        {
+            res_domain |= lhs_partition;
+        }
+        for (const auto& rhs_partition : rhs.partitions)
+        {
+            res_domain |= rhs_partition;
+        }
+        partitions.push_back(res_domain);
+
+        ebpf_value_partition_domain_t res;
+        res.partitions = std::move(partitions);
+        return res;
+    }
+
+
+    // Copy all non-bottom partitions from the left-hand side.
+    for (const auto& lhs_partition : lhs.partitions)
+    {
+       if (!lhs_partition.is_bottom())
+       {
+           partitions.push_back(lhs_partition);
+       }
+    }
+
+    // Copy all non-bottom partitions from the right-hand side.
+    for (const auto& rhs_partition : rhs.partitions)
+    {
+       if (!rhs_partition.is_bottom())
+       {
+           partitions.push_back(rhs_partition);
+       }
+    }
+
+
+    // Sort the partitions by the packet size interval.
+    std::sort(partitions.begin(), partitions.end(), [](const auto& lhs, const auto& rhs) {
+       auto lhs_interval = lhs.m_inv[variable_t::packet_size()];
+       auto rhs_interval = rhs.m_inv[variable_t::packet_size()];
+
+       if (lhs_interval.is_bottom())
+       {
+           return false;
+       }
+       if (rhs_interval.is_bottom())
+       {
+           return true;
+       }
+
+       if (lhs_interval.lb() < rhs_interval.lb())
+       {
+           return true;
+       } else if (lhs_interval.lb() > rhs_interval.lb())
+       {
+           return false;
+       }
+       else
+       {
+           return lhs_interval.ub() < rhs_interval.ub();
+       }
+    });
+
+    // Merge partitions that have the same packet size interval.
+    for (size_t i = 0; i < partitions.size(); i++)
+    {
+       for (size_t j = i + 1; j < partitions.size(); j++)
+       {
+           if (partitions[i].m_inv[variable_t::packet_size()] == partitions[j].m_inv[variable_t::packet_size()])
+           {
+               partitions[i] |= partitions[j];
+               partitions.erase(partitions.begin() + j);
+               j--;
+           }
+           else
+           {
+               break;
+           }
+       }
+    }
+
+    ebpf_value_partition_domain_t res;
+
+    res.partitions = std::move(partitions);
+
+    return res;
+}
+
+void ebpf_value_partition_domain_t::operator|=(ebpf_value_partition_domain_t&& other) {
+    *this = join(*this, std::move(other));
+}
+
+void ebpf_value_partition_domain_t::operator|=(const ebpf_value_partition_domain_t& other) {
+    *this = join(*this, other);
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(ebpf_value_partition_domain_t&& other) const {
+    return join(*this, std::move(other));
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) const& {
+    return join(*this, other);
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) && {
+    return std::move(join(*this, other));
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator&(const ebpf_value_partition_domain_t& other) const
+{
+    ebpf_value_partition_domain_t lhs = *this;
+    ebpf_value_partition_domain_t rhs = other;
+    ebpf_value_partition_domain_t res;
+
+    lhs.merge_all_partitions();
+    rhs.merge_all_partitions();
+
+    res.partitions[0] = lhs.partitions[0] & rhs.partitions[0];
+
+    return res;
+}
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::widen(const ebpf_value_partition_domain_t& other, bool to_constants)
+{
+    ebpf_value_partition_domain_t lhs = *this;
+    ebpf_value_partition_domain_t rhs = other;
+    ebpf_value_partition_domain_t res;
+
+    lhs.merge_all_partitions();
+    rhs.merge_all_partitions();
+
+    res.partitions[0] = lhs.partitions[0].widen(rhs.partitions[0], to_constants);
+
+    return res;
+}
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::narrow(const ebpf_value_partition_domain_t& other)
+{
+    ebpf_value_partition_domain_t lhs = *this;
+    ebpf_value_partition_domain_t rhs = other;
+    ebpf_value_partition_domain_t res;
+
+    lhs.merge_all_partitions();
+    rhs.merge_all_partitions();
+
+    res.partitions[0] = lhs.partitions[0].narrow(rhs.partitions[0]);
+
+    return res;
+}
+
+void ebpf_value_partition_domain_t::set_require_check(std::function<check_require_func_t> f)
+{
+    merge_all_partitions();
+    for (auto& partition : partitions)
+    {
+        partition.set_require_check(f);
+    }
+}
+bound_t ebpf_value_partition_domain_t::get_loop_count_upper_bound()
+{
+    merge_all_partitions();
+    bound_t ub{number_t{0}};
+    for (auto& partition : partitions)
+    {
+        ub = std::max(ub, partition.get_loop_count_upper_bound());
+    }
+    return ub;
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::setup_entry(bool init_r1)
+{
+    ebpf_value_partition_domain_t abs;
+    abs.partitions[0] = ebpf_domain_t::setup_entry(init_r1);
+    return abs;
+}
+
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::from_constraints(const std::set<std::string>& constraints, bool setup_constraints)
+{
+    ebpf_value_partition_domain_t abs;
+    abs.partitions[0] = ebpf_domain_t::from_constraints(constraints, setup_constraints);
+    return abs;
+}
+
+string_invariant ebpf_value_partition_domain_t::to_set()
+{
+    ebpf_value_partition_domain_t tmp = *this;
+    tmp.merge_all_partitions();
+    return tmp.partitions[0].to_set();
+}
+
+// abstract transformers
+
+void ebpf_value_partition_domain_t::initialize_loop_counter(label_t label)
+{
+    merge_all_partitions();
+
+    for (auto& partition : partitions)
+    {
+        partition.initialize_loop_counter(label);
+    }
+}
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::calculate_constant_limits()
+{
+    ebpf_value_partition_domain_t abs;
+    abs.partitions[0] = ebpf_domain_t::calculate_constant_limits();
+    return abs;
+}
+
+std::ostream& operator<<(std::ostream& o, const ebpf_value_partition_domain_t& dom) {
+    ebpf_value_partition_domain_t tmp = dom;
+    tmp.merge_all_partitions();
+    o << tmp.partitions[0];
+    return o;
+}
+
+void ebpf_value_partition_domain_t::merge_all_partitions()
+{
+    if (partitions.size() == 0)
+    {
+        set_to_bottom();
+    }
+    else if (partitions.size() == 1)
+    {
+        // Nothing to do.
+    }
+    else {
+        // Merge all partitions into the first one.
+        for (size_t i = 1; i < partitions.size(); i++)
+        {
+            partitions[0] |= partitions[i];
+        }
+        partitions.resize(1);
+    }
+}
+
+} // namespace crab

--- a/src/crab/ebpf_value_partition_domain.cpp
+++ b/src/crab/ebpf_value_partition_domain.cpp
@@ -155,7 +155,7 @@ ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& ot
     return join(*this, other);
 }
 
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) && {
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::operator|(const ebpf_value_partition_domain_t& other) const && {
     return std::move(join(*this, other));
 }
 
@@ -169,7 +169,7 @@ ebpf_value_partition_domain_t::operator&(const ebpf_value_partition_domain_t& ot
     return std::move(partitions);
 }
 ebpf_value_partition_domain_t ebpf_value_partition_domain_t::widen(const ebpf_value_partition_domain_t& other,
-                                                                   bool to_constants) {
+                                                                   bool to_constants) const {
     std::vector<ebpf_domain_t> partitions;
     merge_or_apply_to_all_partitions(other,
                                      [&partitions, to_constants](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) {
@@ -178,7 +178,7 @@ ebpf_value_partition_domain_t ebpf_value_partition_domain_t::widen(const ebpf_va
 
     return std::move(partitions);
 }
-ebpf_value_partition_domain_t ebpf_value_partition_domain_t::narrow(const ebpf_value_partition_domain_t& other) {
+ebpf_value_partition_domain_t ebpf_value_partition_domain_t::narrow(const ebpf_value_partition_domain_t& other) const {
     std::vector<ebpf_domain_t> partitions;
     merge_or_apply_to_all_partitions(other, [&partitions](const ebpf_domain_t& lhs, const ebpf_domain_t& rhs) {
         partitions.push_back(lhs.narrow(rhs));
@@ -220,6 +220,7 @@ string_invariant ebpf_value_partition_domain_t::to_set() {
 }
 
 void ebpf_value_partition_domain_t::initialize_loop_counter(label_t label) {
+    // Do we really need to merge all partitions here?
     merge_all_partitions();
 
     for (auto& partition : partitions) {

--- a/src/crab/ebpf_value_partition_domain.hpp
+++ b/src/crab/ebpf_value_partition_domain.hpp
@@ -6,8 +6,8 @@
 
 #include <functional>
 #include <optional>
-#include <vector>
 #include <variant>
+#include <vector>
 
 #include "crab/array_domain.hpp"
 #include "crab/split_dbm.hpp"
@@ -18,20 +18,29 @@
 
 namespace crab {
 
+/**
+ * @brief This class represents a set of ebpf_domain_t instances, where each instance has a distinct partition based on
+ * the packet_size variable. Operations are broadcasted to all partitions. Functions that generate new instances (e.g.,
+ * widening) are implemented by applying the function to each partition, potentially merging them if they are have
+ * different partitions.
+ */
 class ebpf_value_partition_domain_t {
-public:
+  public:
     ebpf_value_partition_domain_t();
     ebpf_value_partition_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
     ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain);
+    ebpf_value_partition_domain_t(std::vector<ebpf_domain_t>&& partitions);
 
     // Generic abstract domain operations
     static ebpf_value_partition_domain_t top();
     static ebpf_value_partition_domain_t bottom();
     void set_to_top();
     void set_to_bottom();
-    [[nodiscard]] bool is_bottom() const;
-    [[nodiscard]] bool is_top() const;
-    bool operator<=(const ebpf_value_partition_domain_t& other);
+    [[nodiscard]]
+    bool is_bottom() const;
+    [[nodiscard]]
+    bool is_top() const;
+    bool operator<=(const ebpf_value_partition_domain_t& other) const;
     bool operator==(const ebpf_value_partition_domain_t& other) const;
     void operator|=(ebpf_value_partition_domain_t&& other);
     void operator|=(const ebpf_value_partition_domain_t& other);
@@ -40,7 +49,8 @@ public:
     ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) &&;
     ebpf_value_partition_domain_t operator&(const ebpf_value_partition_domain_t& other) const;
     ebpf_value_partition_domain_t widen(const ebpf_value_partition_domain_t& other, bool to_constants);
-    ebpf_value_partition_domain_t widening_thresholds(const ebpf_value_partition_domain_t& other, const crab::iterators::thresholds_t& ts);
+    ebpf_value_partition_domain_t widening_thresholds(const ebpf_value_partition_domain_t& other,
+                                                      const crab::iterators::thresholds_t& ts);
     ebpf_value_partition_domain_t narrow(const ebpf_value_partition_domain_t& other);
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
@@ -48,14 +58,21 @@ public:
     bound_t get_loop_count_upper_bound();
     static ebpf_value_partition_domain_t setup_entry(bool init_r1);
 
-    static ebpf_value_partition_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
+    static ebpf_value_partition_domain_t from_constraints(const std::set<std::string>& constraints,
+                                                          bool setup_constraints);
     string_invariant to_set();
 
     // abstract transformers
 
+    /**
+     * @brief Forward the given statement to all partitions.
+     *
+     * @tparam statement_t The type of the statement.
+     * @param[in] stmt The statement to forward.
+     */
     template <typename statement_t>
     void operator()(const statement_t& stmt) {
-        for (auto & partition : partitions) {
+        for (auto& partition : partitions) {
             partition(stmt);
         }
     }
@@ -67,10 +84,38 @@ public:
 
     void merge_all_partitions();
 
-private:
-    static ebpf_value_partition_domain_t join(const ebpf_value_partition_domain_t& lhs, const ebpf_value_partition_domain_t& rhs);
+  private:
+    /**
+     * @brief Given two value partition domains, form a new domain that contains a set of partitions that is the union
+     * of the partitions in the two input domains. Partitions are merged if they have the same packet_size variable.
+     *
+     * @param[in] lhs Left-hand side of the join operation.
+     * @param[in] rhs Right-hand side of the join operation.
+     * @return Combined domain.
+     */
+    static ebpf_value_partition_domain_t join(const ebpf_value_partition_domain_t& lhs,
+                                              const ebpf_value_partition_domain_t& rhs);
 
-  std::vector<ebpf_domain_t> partitions;
+    /**
+     * @brief Check if the two value partition domains have the same partitions based on the packet_size variable.
+     *
+     * @param[in] other The other value partition domain to compare with.
+     * @return true There are the same number of partitions and they have the same packet_size variable.
+     * @return false The two domains have different partitions.
+     */
+    bool has_same_partitions(const ebpf_value_partition_domain_t& other) const;
+
+    /**
+     * @brief Given to value partition domains, apply the given function to each partition in both domains. If the
+     * domains have different partitions, merge them first.
+     *
+     * @param[in] other Other value partition domain.
+     * @param[in] f Function to apply to each partition.
+     */
+    void merge_or_apply_to_all_partitions(const ebpf_value_partition_domain_t& other,
+                                          std::function<void(const ebpf_domain_t&, const ebpf_domain_t&)> f) const;
+
+    std::vector<ebpf_domain_t> partitions;
 };
 
 } // namespace crab

--- a/src/crab/ebpf_value_partition_domain.hpp
+++ b/src/crab/ebpf_value_partition_domain.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) Prevail Verifier contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// This file is eBPF-specific, not derived from CRAB.
+
+#include <functional>
+#include <optional>
+#include <vector>
+#include <variant>
+
+#include "crab/array_domain.hpp"
+#include "crab/split_dbm.hpp"
+#include "crab/variable.hpp"
+#include "string_constraints.hpp"
+
+#include "crab/ebpf_domain.hpp"
+
+namespace crab {
+
+class ebpf_value_partition_domain_t {
+public:
+    ebpf_value_partition_domain_t();
+    ebpf_value_partition_domain_t(crab::domains::NumAbsDomain inv, crab::domains::array_domain_t stack);
+    ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain);
+
+    // Generic abstract domain operations
+    static ebpf_value_partition_domain_t top();
+    static ebpf_value_partition_domain_t bottom();
+    void set_to_top();
+    void set_to_bottom();
+    [[nodiscard]] bool is_bottom() const;
+    [[nodiscard]] bool is_top() const;
+    bool operator<=(const ebpf_value_partition_domain_t& other);
+    bool operator==(const ebpf_value_partition_domain_t& other) const;
+    void operator|=(ebpf_value_partition_domain_t&& other);
+    void operator|=(const ebpf_value_partition_domain_t& other);
+    ebpf_value_partition_domain_t operator|(ebpf_value_partition_domain_t&& other) const;
+    ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) const&;
+    ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) &&;
+    ebpf_value_partition_domain_t operator&(const ebpf_value_partition_domain_t& other) const;
+    ebpf_value_partition_domain_t widen(const ebpf_value_partition_domain_t& other, bool to_constants);
+    ebpf_value_partition_domain_t widening_thresholds(const ebpf_value_partition_domain_t& other, const crab::iterators::thresholds_t& ts);
+    ebpf_value_partition_domain_t narrow(const ebpf_value_partition_domain_t& other);
+
+    typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
+    void set_require_check(std::function<check_require_func_t> f);
+    bound_t get_loop_count_upper_bound();
+    static ebpf_value_partition_domain_t setup_entry(bool init_r1);
+
+    static ebpf_value_partition_domain_t from_constraints(const std::set<std::string>& constraints, bool setup_constraints);
+    string_invariant to_set();
+
+    // abstract transformers
+
+    template <typename statement_t>
+    void operator()(const statement_t& stmt) {
+        for (auto & partition : partitions) {
+            partition(stmt);
+        }
+    }
+
+    void initialize_loop_counter(label_t label);
+    static ebpf_value_partition_domain_t calculate_constant_limits();
+
+    friend std::ostream& operator<<(std::ostream& o, const ebpf_value_partition_domain_t& dom);
+
+    void merge_all_partitions();
+
+private:
+    static ebpf_value_partition_domain_t join(const ebpf_value_partition_domain_t& lhs, const ebpf_value_partition_domain_t& rhs);
+
+  std::vector<ebpf_domain_t> partitions;
+};
+
+} // namespace crab

--- a/src/crab/ebpf_value_partition_domain.hpp
+++ b/src/crab/ebpf_value_partition_domain.hpp
@@ -46,12 +46,12 @@ class ebpf_value_partition_domain_t {
     void operator|=(const ebpf_value_partition_domain_t& other);
     ebpf_value_partition_domain_t operator|(ebpf_value_partition_domain_t&& other) const;
     ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) const&;
-    ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) &&;
+    ebpf_value_partition_domain_t operator|(const ebpf_value_partition_domain_t& other) const&&;
     ebpf_value_partition_domain_t operator&(const ebpf_value_partition_domain_t& other) const;
-    ebpf_value_partition_domain_t widen(const ebpf_value_partition_domain_t& other, bool to_constants);
+    ebpf_value_partition_domain_t widen(const ebpf_value_partition_domain_t& other, bool to_constants) const;
     ebpf_value_partition_domain_t widening_thresholds(const ebpf_value_partition_domain_t& other,
-                                                      const crab::iterators::thresholds_t& ts);
-    ebpf_value_partition_domain_t narrow(const ebpf_value_partition_domain_t& other);
+                                                      const crab::iterators::thresholds_t& ts)  const;
+    ebpf_value_partition_domain_t narrow(const ebpf_value_partition_domain_t& other) const;
 
     typedef bool check_require_func_t(NumAbsDomain&, const linear_constraint_t&, std::string);
     void set_require_check(std::function<check_require_func_t> f);
@@ -75,6 +75,7 @@ class ebpf_value_partition_domain_t {
         for (auto& partition : partitions) {
             partition(stmt);
         }
+        // Should we drop bottom partitions here?
     }
 
     void initialize_loop_counter(label_t label);
@@ -82,9 +83,9 @@ class ebpf_value_partition_domain_t {
 
     friend std::ostream& operator<<(std::ostream& o, const ebpf_value_partition_domain_t& dom);
 
+  private:
     void merge_all_partitions();
 
-  private:
     /**
      * @brief Given two value partition domains, form a new domain that contains a set of partitions that is the union
      * of the partitions in the two input domains. Partitions are merged if they have the same packet_size variable.

--- a/src/crab/ebpf_value_partition_domain.hpp
+++ b/src/crab/ebpf_value_partition_domain.hpp
@@ -31,6 +31,9 @@ class ebpf_value_partition_domain_t {
     ebpf_value_partition_domain_t(ebpf_domain_t ebpf_domain);
     ebpf_value_partition_domain_t(std::vector<ebpf_domain_t>&& partitions);
 
+    static void set_partition_keys(const std::vector<std::string>& keys) { partition_keys = {keys}; }
+    static void clear_partition_keys() { partition_keys.reset(); }
+
     // Generic abstract domain operations
     static ebpf_value_partition_domain_t top();
     static ebpf_value_partition_domain_t bottom();
@@ -130,7 +133,24 @@ class ebpf_value_partition_domain_t {
     void merge_or_apply_to_all_partitions(const ebpf_value_partition_domain_t& other,
                                           std::function<void(const ebpf_domain_t&, const ebpf_domain_t&)> f) const;
 
+
+    enum class partition_comparison_t {
+        LESS_THAN,
+        EQUAL,
+        GREATER_THAN,
+    };
+
+    /**
+     * @brief Compare two partitions based on the partition keys.
+     *
+     * @param[in] lhs Left-hand side of the comparison.
+     * @param[in] rhs Right-hand side of the comparison.
+     * @return partition_comparison_t The result of the comparison.
+     */
+    static partition_comparison_t compare_partitions(const ebpf_domain_t& lhs, const ebpf_domain_t& rhs);
+
     std::vector<ebpf_domain_t> partitions;
+    inline static thread_local std::optional<std::vector<std::string>> partition_keys = {};
 };
 
 } // namespace crab

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -94,6 +94,17 @@ class interleaved_fwd_fixpoint_iterator_t final {
 
     domain_t join_all_prevs(const label_t& node) {
         domain_t res = domain_t::bottom();
+        // If this is a ebpf_value_partition_domain_t, set the partition key from the thread_options.
+        if constexpr (std::is_same_v<domain_t, ebpf_value_partition_domain_t>) {
+            std::ostringstream oss;
+            oss << node;
+            std::string node_str = oss.str();
+            if (thread_local_options.label_to_partition_key.contains(node_str)) {
+                res.set_key(thread_local_options.label_to_partition_key.at(node_str));
+            }else  if (thread_local_options.label_to_partition_key.contains("*")) {
+                res.set_key(thread_local_options.label_to_partition_key.at("*"));
+            }
+        }
         for (const label_t& prev : _cfg.prev_nodes(node)) {
             res |= get_post(prev);
         }

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -95,7 +95,6 @@ class interleaved_fwd_fixpoint_iterator_t final {
     domain_t join_all_prevs(const label_t& node) {
         domain_t res = domain_t::bottom();
         for (const label_t& prev : _cfg.prev_nodes(node)) {
-            //std::cout << "Joining " << prev << " with " << node << "\n";
             res |= get_post(prev);
         }
         return res;

--- a/src/crab/fwd_analyzer.cpp
+++ b/src/crab/fwd_analyzer.cpp
@@ -7,6 +7,7 @@
 #include "crab/wto.hpp"
 
 #include "crab/ebpf_domain.hpp"
+#include "crab/ebpf_value_partition_domain.hpp"
 #include "crab/fwd_analyzer.hpp"
 
 namespace crab {
@@ -41,12 +42,17 @@ class member_component_visitor final {
     [[nodiscard]] bool is_member() const { return _found; }
 };
 
+template <typename domain_t>
+std::pair<invariant_table_t<domain_t>, invariant_table_t<domain_t>> run_forward_analyzer(cfg_t& cfg,
+                                                                                         domain_t entry_inv);
+
+template <typename domain_t = ebpf_domain_t>
 class interleaved_fwd_fixpoint_iterator_t final {
-    using iterator = typename invariant_table_t::iterator;
+    using iterator = typename invariant_table_t<domain_t>::iterator;
 
     cfg_t& _cfg;
     wto_t _wto;
-    invariant_table_t _pre, _post;
+    invariant_table_t<domain_t> _pre, _post;
 
     /// number of narrowing iterations. If the narrowing operator is
     /// indeed a narrowing operator this parameter is not
@@ -59,15 +65,15 @@ class interleaved_fwd_fixpoint_iterator_t final {
     bool _skip{true};
 
   private:
-    void set_pre(const label_t& label, const ebpf_domain_t& v) { _pre[label] = v; }
+    void set_pre(const label_t& label, const domain_t& v) { _pre[label] = v; }
 
-    void transform_to_post(const label_t& label, ebpf_domain_t pre) {
+    void transform_to_post(const label_t& label, domain_t pre) {
         basic_block_t& bb = _cfg.get_node(label);
         pre(bb);
         _post[label] = std::move(pre);
     }
 
-    [[nodiscard]] static ebpf_domain_t extrapolate(ebpf_domain_t before, const ebpf_domain_t& after,
+    [[nodiscard]] static domain_t extrapolate(domain_t before, const domain_t& after,
                                                    unsigned int iteration) {
         /// number of iterations until triggering widening
         constexpr auto _widening_delay = 2;
@@ -78,7 +84,7 @@ class interleaved_fwd_fixpoint_iterator_t final {
         return before.widen(after, iteration == _widening_delay);
     }
 
-    static ebpf_domain_t refine(ebpf_domain_t before, const ebpf_domain_t& after, unsigned int iteration) {
+    static domain_t refine(domain_t before, const domain_t& after, unsigned int iteration) {
         if (iteration == 1) {
             return before & after;
         } else {
@@ -86,9 +92,10 @@ class interleaved_fwd_fixpoint_iterator_t final {
         }
     }
 
-    ebpf_domain_t join_all_prevs(const label_t& node) {
-        ebpf_domain_t res = ebpf_domain_t::bottom();
+    domain_t join_all_prevs(const label_t& node) {
+        domain_t res = domain_t::bottom();
         for (const label_t& prev : _cfg.prev_nodes(node)) {
+            //std::cout << "Joining " << prev << " with " << node << "\n";
             res |= get_post(prev);
         }
         return res;
@@ -97,45 +104,64 @@ class interleaved_fwd_fixpoint_iterator_t final {
   public:
     explicit interleaved_fwd_fixpoint_iterator_t(cfg_t& cfg) : _cfg(cfg), _wto(cfg) {
         for (const auto& label : _cfg.labels()) {
-            _pre.emplace(label, ebpf_domain_t::bottom());
-            _post.emplace(label, ebpf_domain_t::bottom());
+            _pre.emplace(label, domain_t::bottom());
+            _post.emplace(label, domain_t::bottom());
         }
     }
 
-    ebpf_domain_t get_pre(const label_t& node) { return _pre.at(node); }
+    domain_t get_pre(const label_t& node) { return _pre.at(node); }
 
-    ebpf_domain_t get_post(const label_t& node) { return _post.at(node); }
+    domain_t get_post(const label_t& node) { return _post.at(node); }
 
     void operator()(const label_t& node);
 
     void operator()(std::shared_ptr<wto_cycle_t>& cycle);
 
-    friend std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, ebpf_domain_t entry_inv);
-};
-
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, ebpf_domain_t entry_inv) {
-    // Go over the CFG in weak topological order (accounting for loops).
-    interleaved_fwd_fixpoint_iterator_t analyzer(cfg);
-    if (thread_local_options.check_termination) {
-        std::vector<label_t> cycle_heads;
-        for (auto& component : analyzer._wto) {
-            if (std::holds_alternative<std::shared_ptr<wto_cycle_t>>(*component)) {
-                cycle_heads.push_back(std::get<std::shared_ptr<wto_cycle_t>>(*component)->head());
+    static
+    std::pair<invariant_table_t<domain_t>, invariant_table_t<domain_t>> run_forward_analyzer(cfg_t& cfg, domain_t entry_inv) {
+        // Go over the CFG in weak topological order (accounting for loops).
+        interleaved_fwd_fixpoint_iterator_t analyzer(cfg);
+        if (thread_local_options.check_termination) {
+            std::vector<label_t> cycle_heads;
+            for (auto& component : analyzer._wto) {
+                if (std::holds_alternative<std::shared_ptr<wto_cycle_t>>(*component)) {
+                    cycle_heads.push_back(std::get<std::shared_ptr<wto_cycle_t>>(*component)->head());
+                }
+            }
+            for (const label_t& label : cycle_heads) {
+                entry_inv.initialize_loop_counter(label);
+                cfg.get_node(label).insert(IncrementLoopCounter{label});
             }
         }
-        for (const label_t& label : cycle_heads) {
-            entry_inv.initialize_loop_counter(label);
-            cfg.get_node(label).insert(IncrementLoopCounter{label});
+        analyzer.set_pre(cfg.entry_label(), entry_inv);
+        for (auto& component : analyzer._wto) {
+            std::visit(analyzer, *component);
         }
+        return std::make_pair(analyzer._pre, analyzer._post);
     }
-    analyzer.set_pre(cfg.entry_label(), entry_inv);
-    for (auto& component : analyzer._wto) {
-        std::visit(analyzer, *component);
-    }
-    return std::make_pair(analyzer._pre, analyzer._post);
+};
+
+template <typename domain_t>
+std::pair<invariant_table_t<domain_t>, invariant_table_t<domain_t>> run_forward_analyzer(cfg_t& cfg,
+                                                                                         domain_t entry_inv) {
+    return interleaved_fwd_fixpoint_iterator_t<domain_t>::run_forward_analyzer(cfg, entry_inv);
 }
 
-void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
+// Reference the template instantiation for ebpf_domain_t and ebpf_value_partition_domain_t.
+
+std::pair<invariant_table_t<crab::ebpf_domain_t>, invariant_table_t<crab::ebpf_domain_t>>
+run_forward_analyzer_ebpf_domain(cfg_t& cfg, crab::ebpf_domain_t entry_inv) {
+    return run_forward_analyzer(cfg, entry_inv);
+}
+
+std::pair<invariant_table_t<crab::ebpf_value_partition_domain_t>,
+                 invariant_table_t<crab::ebpf_value_partition_domain_t>>
+    run_forward_analyzer_ebpf_value_partition_domain(cfg_t& cfg, crab::ebpf_value_partition_domain_t entry_inv) {
+    return run_forward_analyzer(cfg, entry_inv);
+}
+
+template <typename domain_t>
+void interleaved_fwd_fixpoint_iterator_t<domain_t>::operator()(const label_t& node) {
     /** decide whether skip vertex or not **/
     if (_skip && (node == _cfg.entry_label())) {
         _skip = false;
@@ -144,13 +170,14 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(const label_t& node) {
         return;
     }
 
-    ebpf_domain_t pre = node == _cfg.entry_label() ? get_pre(node) : join_all_prevs(node);
+    domain_t pre = node == _cfg.entry_label() ? get_pre(node) : join_all_prevs(node);
 
     set_pre(node, pre);
     transform_to_post(node, pre);
 }
 
-void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t>& cycle) {
+template <typename domain_t>
+void interleaved_fwd_fixpoint_iterator_t<domain_t>::operator()(std::shared_ptr<wto_cycle_t>& cycle) {
     label_t head = cycle->head();
 
     /** decide whether to skip cycle or not **/
@@ -167,7 +194,7 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t
         }
     }
 
-    ebpf_domain_t invariant = ebpf_domain_t::bottom();
+    domain_t invariant = domain_t::bottom();
     if (entry_in_this_cycle) {
         invariant = get_pre(_cfg.entry_label());
     } else {
@@ -188,7 +215,7 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t
             if (!std::holds_alternative<label_t>(c) || (std::get<label_t>(c) != head))
                 std::visit(*this, *component);
         }
-        ebpf_domain_t new_pre = join_all_prevs(head);
+        domain_t new_pre = join_all_prevs(head);
         if (new_pre <= invariant) {
             // Post-fixpoint reached
             set_pre(head, new_pre);
@@ -208,7 +235,7 @@ void interleaved_fwd_fixpoint_iterator_t::operator()(std::shared_ptr<wto_cycle_t
             if (!std::holds_alternative<label_t>(c) || (std::get<label_t>(c) != head))
                 std::visit(*this, *component);
         }
-        ebpf_domain_t new_pre = join_all_prevs(head);
+        domain_t new_pre = join_all_prevs(head);
         if (invariant <= new_pre) {
             // No more refinement possible(pre == new_pre)
             break;

--- a/src/crab/fwd_analyzer.hpp
+++ b/src/crab/fwd_analyzer.hpp
@@ -11,8 +11,11 @@
 
 namespace crab {
 
-using invariant_table_t = std::map<label_t, ebpf_domain_t>;
+template <typename domain_t>
+using invariant_table_t = std::map<label_t, domain_t>;
 
-std::pair<invariant_table_t, invariant_table_t> run_forward_analyzer(cfg_t& cfg, ebpf_domain_t entry_inv);
+template <typename domain_t = ebpf_domain_t>
+std::pair<invariant_table_t<domain_t>, invariant_table_t<domain_t>> run_forward_analyzer(cfg_t& cfg,
+                                                                                         domain_t entry_inv);
 
 } // namespace crab

--- a/src/crab/variable.hpp
+++ b/src/crab/variable.hpp
@@ -49,10 +49,11 @@ class variable_t final {
 
     friend std::ostream& operator<<(std::ostream& o, variable_t v)  { return o << names->at(v._id); }
 
+    static variable_t make(const std::string& name);
+
     // var_factory portion.
     // This singleton is eBPF-specific, to avoid lifetime issues and/or passing factory explicitly everywhere:
   private:
-    static variable_t make(const std::string& name);
     static std::vector<std::string> _default_names();
 
     /**

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -219,8 +219,7 @@ std::tuple<string_invariant, bool> ebpf_analyze_program_for_test(std::ostream& o
                                                                  const program_info& info,
                                                                  const ebpf_verifier_options_t& options)
 {
-    if (!options.partition_keys.empty()) {
-        ebpf_value_partition_domain_t::set_partition_keys(options.partition_keys);
+    if (!options.label_to_partition_key.empty()) {
         return ebpf_analyze_program_for_test_variant<ebpf_value_partition_domain_t>(os, prog, entry_invariant, info, options);
     }
     else {
@@ -240,8 +239,7 @@ bool ebpf_verify_program(std::ostream& os, const InstructionSeq& prog, const pro
     cfg_t cfg = prepare_cfg(prog, info, !options->no_simplify);
 
     checks_db report;
-    if (!options->partition_keys.empty()) {
-        ebpf_value_partition_domain_t::set_partition_keys(options->partition_keys);
+    if (!options->label_to_partition_key.empty()) {
         report = get_ebpf_report<ebpf_value_partition_domain_t>(os, cfg, info, options);
     }
     else {
@@ -265,5 +263,4 @@ void ebpf_verifier_clear_thread_local_state() {
     global_program_info.clear();
     crab::domains::clear_thread_local_state();
     crab::domains::SplitDBM::clear_thread_local_state();
-    crab::ebpf_value_partition_domain_t::clear_partition_keys();
 }

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -219,7 +219,8 @@ std::tuple<string_invariant, bool> ebpf_analyze_program_for_test(std::ostream& o
                                                                  const program_info& info,
                                                                  const ebpf_verifier_options_t& options)
 {
-    if (options.use_value_partitioning) {
+    if (!options.partition_keys.empty()) {
+        ebpf_value_partition_domain_t::set_partition_keys(options.partition_keys);
         return ebpf_analyze_program_for_test_variant<ebpf_value_partition_domain_t>(os, prog, entry_invariant, info, options);
     }
     else {
@@ -239,7 +240,8 @@ bool ebpf_verify_program(std::ostream& os, const InstructionSeq& prog, const pro
     cfg_t cfg = prepare_cfg(prog, info, !options->no_simplify);
 
     checks_db report;
-    if (options->use_value_partitioning) {
+    if (!options->partition_keys.empty()) {
+        ebpf_value_partition_domain_t::set_partition_keys(options->partition_keys);
         report = get_ebpf_report<ebpf_value_partition_domain_t>(os, cfg, info, options);
     }
     else {
@@ -263,4 +265,5 @@ void ebpf_verifier_clear_thread_local_state() {
     global_program_info.clear();
     crab::domains::clear_thread_local_state();
     crab::domains::SplitDBM::clear_thread_local_state();
+    crab::ebpf_value_partition_domain_t::clear_partition_keys();
 }

--- a/src/ebpf_yaml.cpp
+++ b/src/ebpf_yaml.cpp
@@ -106,7 +106,7 @@ struct RawTestCase {
     vector<std::tuple<string, vector<string>>> raw_blocks;
     vector<string> post;
     std::set<string> messages;
-    vector<string> partition_keys;
+    string partition_key;
 };
 
 static vector<string> parse_block(const YAML::Node& block_node) {
@@ -140,7 +140,7 @@ static RawTestCase parse_case(const YAML::Node& case_node) {
         .raw_blocks = parse_code(case_node["code"]),
         .post = case_node["post"].as<vector<string>>(),
         .messages = as_set_empty_default(case_node["messages"]),
-        .partition_keys = case_node["partition_keys"].IsDefined() ? case_node["partition_keys"].as<vector<string>>() : vector<string>(),
+        .partition_key = case_node["partition_key"].IsDefined() ? case_node["partition_key"].as<string>() : string(),
     };
 }
 
@@ -209,7 +209,7 @@ static TestCase read_case(const RawTestCase& raw_case) {
         .instruction_seq = raw_cfg_to_instruction_seq(raw_case.raw_blocks),
         .expected_post_invariant = read_invariant(raw_case.post),
         .expected_messages = raw_case.messages,
-        .partition_keys = raw_case.partition_keys,
+        .partition_key = raw_case.partition_key,
     };
 }
 
@@ -250,7 +250,9 @@ std::optional<Failure> run_yaml_test_case(TestCase test_case, bool debug) {
         test_case.options.no_simplify = true;
     }
 
-    test_case.options.partition_keys = test_case.partition_keys;
+    if (!test_case.partition_key.empty()) {
+        test_case.options.label_to_partition_key.insert({"*", test_case.partition_key});
+    }
 
     ebpf_context_descriptor_t context_descriptor{64, 0, 4, -1};
     EbpfProgramType program_type = make_program_type(test_case.name, &context_descriptor);

--- a/src/ebpf_yaml.hpp
+++ b/src/ebpf_yaml.hpp
@@ -14,6 +14,7 @@ struct TestCase {
     InstructionSeq instruction_seq;
     string_invariant expected_post_invariant;
     std::set<std::string> expected_messages;
+    std::vector<std::string> partition_keys;
 };
 
 void foreach_suite(const std::string& path, const std::function<void(const TestCase&)>& f);

--- a/src/ebpf_yaml.hpp
+++ b/src/ebpf_yaml.hpp
@@ -14,7 +14,7 @@ struct TestCase {
     InstructionSeq instruction_seq;
     string_invariant expected_post_invariant;
     std::set<std::string> expected_messages;
-    std::vector<std::string> partition_keys;
+    std::string partition_key;
 };
 
 void foreach_suite(const std::string& path, const std::function<void(const TestCase&)>& f);

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -132,6 +132,9 @@ int main(int argc, char** argv) {
     app.add_flag("--line-info", ebpf_verifier_options.print_line_info, "Print line information");
     app.add_flag("--print-btf-types", ebpf_verifier_options.dump_btf_types_json, "Print BTF types");
 
+    std::string partition_variable;
+    app.add_option("--partition-variable", partition_variable, "Partition variable")->type_name("VARIABLE");
+
     std::string asmfile;
     app.add_option("--asm", asmfile, "Print disassembly to FILE")->type_name("FILE");
     std::string dotfile;
@@ -143,6 +146,11 @@ int main(int argc, char** argv) {
     if (verbose)
         ebpf_verifier_options.print_invariants = ebpf_verifier_options.print_failures = true;
     ebpf_verifier_options.allow_division_by_zero = !no_division_by_zero;
+
+    if (!partition_variable.empty()) {
+        // partition_variable is a comma-separated list of variables.
+        boost::split(ebpf_verifier_options.partition_keys, partition_variable, boost::is_any_of(","));
+    }
 
     // Enable default conformance groups, which don't include callx or packet.
     ebpf_platform_t platform = g_ebpf_platform_linux;

--- a/src/main/check.cpp
+++ b/src/main/check.cpp
@@ -149,7 +149,17 @@ int main(int argc, char** argv) {
 
     if (!partition_variable.empty()) {
         // partition_variable is a comma-separated list of variables.
-        boost::split(ebpf_verifier_options.partition_keys, partition_variable, boost::is_any_of(","));
+        std::vector<std::string> partition_keys;
+        boost::split(partition_keys, partition_variable, boost::is_any_of(","));
+        for (const auto& partition_key : partition_keys) {
+            std::vector<std::string> label_and_key;
+            boost::split(label_and_key, partition_key, boost::is_any_of("/"));
+            if (label_and_key.size() != 2) {
+                std::cerr << "Invalid partition variable: " << partition_key << std::endl;
+                return 1;
+            }
+            ebpf_verifier_options.label_to_partition_key[label_and_key[0]] = label_and_key[1];
+        }
     }
 
     // Enable default conformance groups, which don't include callx or packet.

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -74,7 +74,7 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
 #define TEST_SECTION_WITH_PARTITION_KEY(project, filename, section, partition_key)                          \
     TEST_CASE("./check ebpf-samples/" project "/" filename " " section, "[verify][samples][" project "]") { \
         ebpf_verifier_options_t options = ebpf_verifier_default_options;                                    \
-        options.partition_keys.push_back(partition_key);                                                    \
+        options.label_to_partition_key.insert({"*", partition_key});                                             \
         VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, true);                 \
     }
 

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -71,6 +71,13 @@ FAIL_UNMARSHAL("invalid", "invalid-lddw.o", ".text")
         VERIFY_SECTION(project, filename, section, nullptr, &g_ebpf_platform_linux, true); \
     }
 
+#define TEST_SECTION_WITH_PARTITION_KEY(project, filename, section, partition_key)                          \
+    TEST_CASE("./check ebpf-samples/" project "/" filename " " section, "[verify][samples][" project "]") { \
+        ebpf_verifier_options_t options = ebpf_verifier_default_options;                                    \
+        options.partition_keys.push_back(partition_key);                                                    \
+        VERIFY_SECTION(project, filename, section, &options, &g_ebpf_platform_linux, true);                 \
+    }
+
 #define TEST_PROGRAM(project, filename, section_name, program_name) \
     TEST_CASE("./check ebpf-samples/" project "/" filename " " program_name, "[verify][samples][" project "]") { \
         VERIFY_PROGRAM(project, filename, section_name, program_name, nullptr, &g_ebpf_platform_linux, true); \
@@ -558,11 +565,11 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/18")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/10")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
 
-TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/19")
-TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/21")
+TEST_SECTION_WITH_PARTITION_KEY("cilium", "bpf_xdp_dsr_linux.o", "2/19", "packet_size")
+TEST_SECTION_WITH_PARTITION_KEY("cilium", "bpf_xdp_dsr_linux.o", "2/20", "packet_size")
+TEST_SECTION_WITH_PARTITION_KEY("cilium", "bpf_xdp_dsr_linux.o", "2/21", "packet_size")
 
-TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "2/19")
-TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/20")
+TEST_SECTION_WITH_PARTITION_KEY("cilium", "bpf_xdp_snat_linux.o", "2/19", "packet_size")
 
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/7")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/15")

--- a/src/test/test_verify.cpp
+++ b/src/test/test_verify.cpp
@@ -546,7 +546,6 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/7")
 // The bigger issue is that the convexity of the numerical domain means that precise handling would still get
 // [-22, -1] which is not sufficient (at most -2 is needed)
 TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/10")
-TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/21")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/24")
 
 TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/15")
@@ -559,18 +558,15 @@ TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/18")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/10")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/18")
 
-TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/19")
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/19")
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/21")
 
-// Failure: 230: Upper bound must be at most packet_size (valid_access(r3.offset+32, width=8) for write)
-// r3.packet_offset=[0, 82] and packet_size=[34, 65534]
-// looks like a combination of misunderstanding the value passed to xdp_adjust_tail()
-// which is "r7.value=[0, 82]; w7 -= r9;" where r9.value where "r7.value-r9.value<=48"
-TEST_SECTION_FAIL("cilium", "bpf_xdp_dsr_linux.o", "2/20")
+TEST_SECTION("cilium", "bpf_xdp_snat_linux.o", "2/19")
+TEST_SECTION("cilium", "bpf_xdp_dsr_linux.o", "2/20")
 
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/7")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/15")
 TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/17")
-TEST_SECTION_FAIL("cilium", "bpf_xdp_snat_linux.o", "2/19")
 
 // Failure (&255): assert r5.type == number; w5 &= 255;
 // fails since in one branch (77) r5 is a number but in another (92:93) it is a packet

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -10,8 +10,8 @@
 #define YAML_CASE(path) \
     TEST_CASE("YAML suite: " path, "[yaml]") { \
         foreach_suite(path, [&](TestCase test_case){ \
-            if (test_case.partition_keys.size() == 1 && test_case.partition_keys[0] == "none") { \
-                test_case.partition_keys.clear(); \
+            if (test_case.partition_key.empty() || test_case.partition_key == "none") { \
+                test_case.partition_key.clear(); \
             } \
             std::optional<Failure> failure = run_yaml_test_case(test_case); \
             if (failure) { \
@@ -22,21 +22,20 @@
         }); \
     }
 
-#define YAML_CASE_WITH_PARTITION(path, partition) \
-    TEST_CASE("YAML suite: " path " with partition " partition, "[yaml]") { \
-        foreach_suite(path, [&](TestCase test_case){ \
-            if (test_case.partition_keys.size() == 1 && test_case.partition_keys[0] == "none") { \
-                /* Skip test cases that are not partitioned */ \
-                return; \
-            } \
-            test_case.partition_keys = {partition}; \
-            std::optional<Failure> failure = run_yaml_test_case(test_case); \
-            if (failure) { \
-                std::cout << "test case: " << test_case.name << "\n"; \
-                print_failure(*failure, std::cout); \
-            } \
-            REQUIRE(!failure); \
-        }); \
+#define YAML_CASE_WITH_PARTITION(path, partition)                                       \
+    TEST_CASE("YAML suite: " path " with partition " partition, "[yaml]") {             \
+        foreach_suite(path, [&](TestCase test_case) {                                   \
+            if (test_case.partition_key.empty() || test_case.partition_key == "none") { \
+                /* Skip test cases that are not partitioned */                          \
+                return;                                                                 \
+            }                                                                           \
+            std::optional<Failure> failure = run_yaml_test_case(test_case);             \
+            if (failure) {                                                              \
+                std::cout << "test case: " << test_case.name << "\n";                   \
+                print_failure(*failure, std::cout);                                     \
+            }                                                                           \
+            REQUIRE(!failure);                                                          \
+        });                                                                             \
     }
 
 

--- a/src/test/test_yaml.cpp
+++ b/src/test/test_yaml.cpp
@@ -9,7 +9,10 @@
 
 #define YAML_CASE(path) \
     TEST_CASE("YAML suite: " path, "[yaml]") { \
-        foreach_suite(path, [&](const TestCase& test_case){ \
+        foreach_suite(path, [&](TestCase test_case){ \
+            if (test_case.partition_keys.size() == 1 && test_case.partition_keys[0] == "none") { \
+                test_case.partition_keys.clear(); \
+            } \
             std::optional<Failure> failure = run_yaml_test_case(test_case); \
             if (failure) { \
                 std::cout << "test case: " << test_case.name << "\n"; \
@@ -18,6 +21,24 @@
             REQUIRE(!failure); \
         }); \
     }
+
+#define YAML_CASE_WITH_PARTITION(path, partition) \
+    TEST_CASE("YAML suite: " path " with partition " partition, "[yaml]") { \
+        foreach_suite(path, [&](TestCase test_case){ \
+            if (test_case.partition_keys.size() == 1 && test_case.partition_keys[0] == "none") { \
+                /* Skip test cases that are not partitioned */ \
+                return; \
+            } \
+            test_case.partition_keys = {partition}; \
+            std::optional<Failure> failure = run_yaml_test_case(test_case); \
+            if (failure) { \
+                std::cout << "test case: " << test_case.name << "\n"; \
+                print_failure(*failure, std::cout); \
+            } \
+            REQUIRE(!failure); \
+        }); \
+    }
+
 
 YAML_CASE("test-data/add.yaml")
 YAML_CASE("test-data/assign.yaml")
@@ -39,3 +60,24 @@ YAML_CASE("test-data/stack.yaml")
 YAML_CASE("test-data/subtract.yaml")
 YAML_CASE("test-data/unop.yaml")
 YAML_CASE("test-data/unsigned.yaml")
+
+YAML_CASE_WITH_PARTITION("test-data/add.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/assign.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/atomic.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/bitop.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/call.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/callx.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/udivmod.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/sdivmod.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/full64.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/jump.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/loop.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/movsx.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/packet.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/parse.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/sext.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/shift.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/stack.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/subtract.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/unop.yaml", "packet_size");
+YAML_CASE_WITH_PARTITION("test-data/unsigned.yaml", "packet_size");

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -536,6 +536,50 @@ post:
 messages:
   - "7:9: Code is unreachable after 7:9"
 ---
+test-case: lost implications in correlated branches - with packet_size partition
+
+partition_keys: ["packet_size"]
+
+pre: ["meta_offset=0", "packet_size=[36, 65534]",
+      "r1.type=packet", "r1.packet_offset=54",
+      "r2.type=packet", "r2.packet_offset=packet_size"]
+
+code:
+  <start>: |
+    r0 = 0
+    if r1 > r2 goto <bad>
+    r4 = 0                ; r1 is within packet
+    goto <join>
+  <bad>: |
+    r4 = 1                ; r1 is past end of packet
+    goto <join>
+  <join>: |
+    if r4 == 1 goto <end> ; skip to end if r1 is past end of packet
+    r0 = *(u64 *)(r1 - 8) ; this should be safe to dereference but the verifier fails it
+  <end>: |
+    exit
+
+post:
+  - meta_offset=0
+  - packet_size=[36, 65534]
+  - packet_size=r2.packet_offset
+  - packet_size-r1.packet_offset<=65480
+  - r0.type=number
+  - r1.type=packet
+  - r1.packet_offset=54
+  - r1.packet_offset-packet_size<=18
+  - r1.packet_offset-r2.packet_offset<=18
+  - r2.type=packet
+  - r2.packet_offset=[36, 65534]
+  - r2.packet_offset-r1.packet_offset<=65480
+  - r4.type=number
+  - r4.svalue=[0, 1]
+  - r4.uvalue=[0, 1]
+  - r4.svalue=r4.uvalue
+
+messages:
+---
+partition_keys: ["none"]
 test-case: lost implications in correlated branches
 
 pre: ["meta_offset=0", "packet_size=[36, 65534]",
@@ -576,6 +620,7 @@ post:
   - r4.svalue=r4.uvalue
 
 messages:
+  - "7: Upper bound must be at most packet_size (valid_access(r1.offset-8, width=8) for read)"
 ---
 test-case: 32-bit compare
 

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -576,7 +576,6 @@ post:
   - r4.svalue=r4.uvalue
 
 messages:
-  - "7: Upper bound must be at most packet_size (valid_access(r1.offset-8, width=8) for read)"
 ---
 test-case: 32-bit compare
 

--- a/test-data/jump.yaml
+++ b/test-data/jump.yaml
@@ -538,7 +538,7 @@ messages:
 ---
 test-case: lost implications in correlated branches - with packet_size partition
 
-partition_keys: ["packet_size"]
+partition_key: "packet_size"
 
 pre: ["meta_offset=0", "packet_size=[36, 65534]",
       "r1.type=packet", "r1.packet_offset=54",
@@ -579,7 +579,7 @@ post:
 
 messages:
 ---
-partition_keys: ["none"]
+partition_key: "none"
 test-case: lost implications in correlated branches
 
 pre: ["meta_offset=0", "packet_size=[36, 65534]",


### PR DESCRIPTION
This pull request introduces significant changes to the eBPF verifier, with the introduction of a new domain, `ebpf_value_partition_domain_t`, that represents a set of `ebpf_domain_t` instances. Each instance has a distinct partition based on the packet size variable. The pull request also includes changes to the `ebpf_domain_t` and `ebpf_verifier_options_t` classes, and updates to several files to accommodate the new domain.

Here are the most important changes:

New domain:

* [`src/crab/ebpf_value_partition_domain.cpp`](diffhunk://#diff-050094071616fd214cb15670a04b6af0ac827dd269d65efc039e4dccfc30fb04R1-R288): Added a new file that implements the `ebpf_value_partition_domain_t` class. This class represents a set of `ebpf_domain_t` instances, where each instance has a distinct partition based on the packet size variable. Operations are broadcasted to all partitions. Functions that generate new instances (e.g., widening) are implemented by applying the function to each partition, potentially merging them if they have different partitions.

* [`src/crab/ebpf_value_partition_domain.hpp`](diffhunk://#diff-29da9b6545027b8e88bd9705343fe8304f130636412acc5d34eb486628786512R1-R121): Added a new file that declares the `ebpf_value_partition_domain_t` class.

Changes to existing classes:

* [`src/config.hpp`](diffhunk://#diff-7d36a3982a659a42ce27f280729500523eb3cbe86ffdc80713f6b4aa83cc44d0R24): Added a new member, `use_value_partitioning`, to the `ebpf_verifier_options_t` struct.

* [`src/config.cpp`](diffhunk://#diff-6b2f0a449fdefd8930e23ef0dcd752beec69242e1303d77653f047c5e0766385R17): Initialized the `use_value_partitioning` member in the `ebpf_verifier_default_options` object.

* [`src/crab/ebpf_domain.hpp`](diffhunk://#diff-4c452eb5f2e836e43cc312b9df5c1f83edfb1f5d37b6f4e455530aa74f4877caR25-R26): Added a friend class declaration for `ebpf_value_partition_domain_t` in the `ebpf_domain_t` class. Also, changed several methods to be `const` to ensure they don't modify the object. [[1]](diffhunk://#diff-4c452eb5f2e836e43cc312b9df5c1f83edfb1f5d37b6f4e455530aa74f4877caR25-R26) [[2]](diffhunk://#diff-4c452eb5f2e836e43cc312b9df5c1f83edfb1f5d37b6f4e455530aa74f4877caL36-R48)

* [`src/crab/ebpf_domain.cpp`](diffhunk://#diff-4260cca82870d77e078c224955ebce890cb127bdd92fd63a2d57e1374dedd9f2L815-R815): Updated several methods in the `ebpf_domain_t` class to be `const`. [[1]](diffhunk://#diff-4260cca82870d77e078c224955ebce890cb127bdd92fd63a2d57e1374dedd9f2L815-R815) [[2]](diffhunk://#diff-4260cca82870d77e078c224955ebce890cb127bdd92fd63a2d57e1374dedd9f2L948-R955)

Changes to other files:

* [`ebpf-samples`](diffhunk://#diff-d904becaac4afcb6590c90f1ef6bfea125deb117b758dd7ce2425ae4fc030ecbL1-R1): Updated the subproject commit.

* [`src/crab/fwd_analyzer.cpp`](diffhunk://#diff-f17aa118aafd3fa8882c3c01b415a2f9e65aa2020d38700f9ac8791977c69c85R10): Updated the `interleaved_fwd_fixpoint_iterator_t` class to work with a generic domain type instead of `ebpf_domain_t`. [[1]](diffhunk://#diff-f17aa118aafd3fa8882c3c01b415a2f9e65aa2020d38700f9ac8791977c69c85R10) [[2]](diffhunk://#diff-f17aa118aafd3fa8882c3c01b415a2f9e65aa2020d38700f9ac8791977c69c85R45-R55) [[3]](diffhunk://#diff-f17aa118aafd3fa8882c3c01b415a2f9e65aa2020d38700f9ac8791977c69c85L62-R76) [[4]](diffhunk://#diff-f17aa118aafd3fa8882c3c01b415a2f9e65aa2020d38700f9ac8791977c69c85L81-R96)