### PR TITLE
Testing lcov options

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Generate code coverage report
         run: |
           mkdir coverage
-          lcov --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
+          lcov --ignore-errors all --capture --directory build --include '*/ebpf-verifier/src/*' --output-file coverage/lcov.info
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
This pull request includes a modification to the `.github/workflows/coverage.yml` file to improve the code coverage report generation process by ignoring all errors during the lcov capture.

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L45-R45): Added `--ignore-errors all` to the `lcov` command to ensure that errors are ignored during the capture process.