### PR TITLE
Verifier fuzzing support

### DIFF
--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -210,7 +210,7 @@ class SplitDBM final {
 
     [[nodiscard]]
     SplitDBM widening_thresholds(const SplitDBM& o, const iterators::thresholds_t&) const {
-        // TODO: use thresholds. For now, make thresholds an anonymous argument to avoid unused parameter warning.
+        // TODO: use thresholds. Threshold is anonymous until used to prevent unused parameter warning.
         return this->widen(o);
     }
 

--- a/src/crab/split_dbm.hpp
+++ b/src/crab/split_dbm.hpp
@@ -210,7 +210,7 @@ class SplitDBM final {
 
     [[nodiscard]]
     SplitDBM widening_thresholds(const SplitDBM& o, const iterators::thresholds_t&) const {
-        // TODO: use thresholds. Threshold is anonymous until used to prevent unused parameter warning.
+        // TODO: use thresholds. For now, make thresholds an anonymous argument to avoid unused parameter warning.
         return this->widen(o);
     }
 

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -30,6 +30,12 @@ bool Invariants::is_valid_after(const label_t& label, const string_invariant& st
     return abstract_state <= invariants.at(label).post;
 }
 
+bool Invariants::is_valid_before(const label_t& label, const string_invariant& state) const {
+    const ebpf_domain_t abstract_state =
+        ebpf_domain_t::from_constraints(state.value(), thread_local_options.setup_constraints);
+    return abstract_state <= invariants.at(label).pre;
+}
+
 string_invariant Invariants::invariant_at(const label_t& label) const { return invariants.at(label).post.to_set(); }
 
 crab::interval_t Invariants::exit_value() const { return invariants.at(label_t::exit).post.get_r0(); }

--- a/src/crab_verifier.cpp
+++ b/src/crab_verifier.cpp
@@ -24,16 +24,31 @@ thread_local crab::lazy_allocator<program_info> thread_local_program_info;
 thread_local ebpf_verifier_options_t thread_local_options;
 void ebpf_verifier_clear_before_analysis();
 
+// Note:
+// The check is intended to find abstract state values that violate the constraints of the
+// pre or post invariant. The check is done by the crab library.
+// There are 4 possible outcomes:
+// 1. The abstract state contains an invariant that is not present in the pre or post invariant.
+// 2. The pre or post invariant contains an invariant that is not present in the abstract state.
+// 3. The abstract state contains an invariant that is present in the pre or post invariant and
+// the value of the invariant is within the constraints of the pre or post invariant.
+// 4. The abstract state contains an invariant that is present in the pre or post invariant, but the
+// value of the invariant is not within the constraints of the pre or post invariant.
+// The check should return false only for the 4th case where there is a violation of the constraints.
+// Usage of <= doesn't work as there are cases where the externally provided state contains constraints
+// that the pre and post invariant doesn't have. Examples are the registers where the pre and post invariant
+// have 'havoc'ed the constraints, but the externally provided state has constraints on the registers.
+
 bool Invariants::is_valid_after(const label_t& label, const string_invariant& state) const {
     const ebpf_domain_t abstract_state =
         ebpf_domain_t::from_constraints(state.value(), thread_local_options.setup_constraints);
-    return abstract_state <= invariants.at(label).post;
+    return !(abstract_state & invariants.at(label).post).is_bottom();
 }
 
 bool Invariants::is_valid_before(const label_t& label, const string_invariant& state) const {
     const ebpf_domain_t abstract_state =
         ebpf_domain_t::from_constraints(state.value(), thread_local_options.setup_constraints);
-    return abstract_state <= invariants.at(label).pre;
+    return !(abstract_state & invariants.at(label).pre).is_bottom();
 }
 
 string_invariant Invariants::invariant_at(const label_t& label) const { return invariants.at(label).post.to_set(); }

--- a/src/crab_verifier.hpp
+++ b/src/crab_verifier.hpp
@@ -58,6 +58,7 @@ class Invariants final {
     Invariants(const Invariants& invariants) = default;
 
     bool is_valid_after(const label_t& label, const string_invariant& state) const;
+    bool is_valid_before(const label_t& label, const string_invariant& state) const;
 
     string_invariant invariant_at(const label_t& label) const;
 


### PR DESCRIPTION
This pull request introduces a new method to the `Invariants` class and modifies an existing method to improve the checking of abstract state values against pre and post invariants. The changes ensure that the checks are more accurate and handle cases where constraints differ between the abstract state and the invariants.

Improvements to invariant checking:

* [`src/crab_verifier.cpp`](diffhunk://#diff-e3c65b3e2779bdd7a17c56ff48fd12ba98fcfcd19ab41081150358a9bbcdf920R27-R51): Added detailed comments explaining the purpose and outcomes of the invariant checks. Modified the `is_valid_after` method to use a more accurate check and added a new `is_valid_before` method to handle pre-invariants.
* [`src/crab_verifier.hpp`](diffhunk://#diff-c4c799663e60b12ae86df5980f7d8eeff2c2b6d091329810e511794ff538ae11R61): Added the declaration of the new `is_valid_before` method to the `Invariants` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced invariant validation logic with a new method to check state validity before a specific label
	- Improved precision of constraint checking for abstract states

- **Refactor**
	- Updated implementation of invariant validation methods to use more robust bitwise operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->