### PR TITLE
Add LLM context document for verification failure diagnosis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This documentation provides a comprehensive guide to understanding the Prevail e
 | [Building](building.md) | Build instructions for all platforms |
 | [Testing](testing.md) | Test infrastructure and conformance testing |
 | [Glossary](glossary.md) | Terminology and definitions |
+| [LLM Context](llm-context.md) | Guide for LLM-assisted failure diagnosis |
 
 ## What is Prevail?
 
@@ -112,7 +113,7 @@ src/
 ## Getting Started
 
 1. **Build the verifier**: See [Building](building.md)
-2. **Run on an ELF file**: `./check path/to/program.o section/function`
+2. **Run on an ELF file**: `./bin/check path/to/program.o section/function`
 3. **Understand the output**: The verifier prints invariants and any errors found
 
 ## Further Reading
@@ -120,3 +121,39 @@ src/
 - [RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html) - BPF Instruction Set Architecture
 - Cousot & Cousot (1977) - Abstract Interpretation foundations
 - Bourdoncle (1993) - Efficient chaotic iteration strategies (WTO)
+
+## LLM-Assisted Diagnosis
+
+When verification fails, you can use an LLM to help diagnose the issue.
+
+**Quick start** (with GitHub Copilot CLI):
+
+```text
+Using docs/llm-context.md, run ./bin/check <your-program.o> <section> -v and diagnose the failure.
+```
+
+**Manual approach** (with any LLM):
+1. Run the verifier with verbose output: `./bin/check program.o section -v`
+2. Copy the contents of `docs/llm-context.md` into your LLM conversation
+3. Paste the verification error and ask for diagnosis
+
+See [llm-context.md](llm-context.md) for the context document and [test-data/llm-context-tests.md](../test-data/llm-context-tests.md) for validated test cases.
+
+### Contributing New Failure Patterns
+
+When you discover a verification failure that isn't covered by the existing patterns in Section 4 of `llm-context.md`, please contribute it:
+
+1. **Identify the pattern**: Run `./bin/check <sample> <section> -v` and capture the error message and pre-invariant
+2. **Add to Section 4**: Create a new subsection (e.g., `### 4.12 <Pattern Name>`) following the existing format:
+   - **Symptom**: The error message text
+   - **Red Flags**: Key invariant properties that indicate this failure
+   - **Cause**: Why the verifier rejects this
+   - **Fix**: How to resolve the issue (code changes or workarounds)
+3. **Add a test case**: Add a corresponding test to `test-data/llm-context-tests.md` with:
+   - The command to reproduce
+   - Expected error message
+   - Pattern reference
+   - Key invariant to look for
+4. **If needed, add a test sample**: If no existing sample triggers the error, add source to `ebpf-samples/src/` and update `ebpf-samples/CMakeLists.txt`
+
+The goal is for LLMs to recognize the failure pattern and suggest the correct fix based on the documented context.

--- a/docs/llm-context.md
+++ b/docs/llm-context.md
@@ -1,0 +1,714 @@
+# LLM Context Document for Prevail eBPF Verifier
+
+This document provides the context needed for an LLM to accurately diagnose eBPF verification failures when given a Prevail log output.
+
+## 1. Overview
+
+**Prevail** is a static verifier for eBPF programs that uses **abstract interpretation** to prove memory safety, type safety, and (optionally) termination without executing the code. Unlike the Linux kernel verifier that simulates execution, Prevail computes **invariants**—logical statements that hold at every program point regardless of input values.
+
+### What Prevail Verifies
+
+1. **Memory safety**: All reads/writes stay within valid memory regions (stack, packet, context, shared/map memory)
+2. **Type safety**: Registers contain the expected types (numbers, pointers to specific regions)
+3. **Pointer arithmetic**: Only numbers can be added to pointers; only compatible pointers can be subtracted
+4. **Division safety**: Divisors are never zero (unless explicitly allowed)
+5. **Helper function contracts**: Arguments match the expected types and bounds
+6. **Termination** (optional): Loops have bounded iteration counts
+
+### How Verification Works
+
+1. **Parse** the eBPF program into a control-flow graph (CFG)
+2. **Initialize** abstract state at entry (context pointer in r1, stack pointer in r10)
+3. **Iterate** to a fixpoint using widening/narrowing to handle loops
+4. **Check assertions** at each program point (memory access, type constraints, etc.)
+5. **Report errors** when an assertion cannot be proven to hold
+
+---
+
+## 2. Understanding Verification Logs
+
+Prevail logs show the abstract state at each program point. Here's how to interpret them.
+
+### 2.1 Log Structure
+
+When running `./bin/check <file> <section> -v`, the verbose output shows:
+
+```text
+Pre-invariant : [
+    <register types>][
+    <numeric constraints>]
+Stack: Numbers -> {<byte ranges>}
+<pc>:<instruction>
+Post-invariant : [
+    <register types>][
+    <numeric constraints>]
+Stack: Numbers -> {<byte ranges>}
+```
+
+On verification failure, you'll see:
+
+```text
+Verification error:
+<Pre-invariant at failing instruction>
+<pc>: <error message>
+```
+
+- **Pre-invariant**: The abstract state *before* executing the instruction
+- **pc**: Program counter (instruction number within the section)
+- **instruction**: The eBPF instruction in human-readable form
+- **Post-invariant**: The abstract state *after* executing the instruction
+
+### 2.2 Register State Format
+
+Each register has multiple abstract properties:
+
+| Property | Meaning |
+|----------|---------|
+| `r<N>.type` | Type: `number`, `ctx`, `stack`, `packet`, `shared`, `map_fd`, or `map_fd_programs` |
+| `r<N>.svalue` | Signed value or interval `[min, max]` |
+| `r<N>.uvalue` | Unsigned value or interval `[min, max]` |
+| `r<N>.ctx_offset` | Offset within context struct (if type=ctx) |
+| `r<N>.stack_offset` | Offset within stack (if type=stack) |
+| `r<N>.packet_offset` | Offset within packet (if type=packet) |
+| `r<N>.shared_offset` | Offset within shared memory (if type=shared) |
+| `r<N>.shared_region_size` | Size of the shared region (for bounds checking) |
+| `r<N>.stack_numeric_size` | Number of contiguous numeric bytes at stack location |
+| `r<N>.map_fd` | Map file descriptor value (if type=map_fd) |
+
+**Interval notation**: `[min, max]` means the value is constrained to that range. `[4098, 2147418112]` is a typical pointer address range.
+
+**Relational constraints**: Entries like `r2.packet_offset=packet_size` indicate relationships between variables.
+
+### 2.3 Stack State Format
+
+Stack memory is tracked separately:
+
+| Property | Meaning |
+|----------|---------|
+| `s[N...M].type` | Type of bytes N through M |
+| `s[N...M].svalue` | Signed value stored at those bytes |
+| `s[N...M].uvalue` | Unsigned value stored at those bytes |
+| `s[N].ctx_offset` | If a pointer is stored, its ctx_offset |
+| `s[N].packet_offset` | If a pointer is stored, its packet_offset |
+
+**Stack Numbers summary**: The line `Stack: Numbers -> {[A...B], [C...D]}` shows which byte ranges are known to contain numeric (non-pointer) data. Empty `{}` means no stack bytes are proven numeric.
+
+Stack offsets `N` in `s[N]` / `s[N...M]` are absolute byte offsets within the total eBPF stack (`0..EBPF_TOTAL_STACK_SIZE-1`). For a given program point, the active stack frame is the interval `[r10.stack_offset-EBPF_SUBPROGRAM_STACK_SIZE, r10.stack_offset)`.
+
+### 2.4 Global State Variables
+
+| Variable | Meaning |
+|----------|---------|
+| `meta_offset` | Offset of packet metadata (negative = before data pointer) |
+| `packet_size` | Packet size constraint |
+| `pc[N]` | Loop counter for basic block N (used in termination checking) |
+
+### 2.5 Error Message Format
+
+Errors follow this pattern:
+
+```text
+<pc>: <reason> (<assertion>)
+```
+
+Where:
+- **pc**: The program counter (or `pc:target` for conditional jumps)
+- **reason**: Human-readable explanation of the failure
+- **assertion**: The formal assertion that failed
+
+**Example errors**:
+
+```text
+0: Invalid type (r3.type in {number, ctx, stack, packet, shared})
+1: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for write)
+0 (counter): Loop counter is too large (pc[0] < 100000)
+```
+
+---
+
+## 3. Glossary of Log Terms
+
+### Types
+
+| Term | Description |
+|------|-------------|
+| `number` | A scalar integer (not a pointer) |
+| `ctx` | Pointer to program context structure (e.g., `xdp_md`, `sk_buff`) |
+| `stack` | Pointer to stack memory (512 bytes per stack frame) |
+| `packet` | Pointer to packet data |
+| `shared` | Pointer to shared memory (e.g., map values) |
+| `map_fd` | Map file descriptor (not directly dereferenceable) |
+| `map_fd_programs` | Program array map FD |
+
+### Type Groups
+
+| Group | Members |
+|-------|---------|
+| `pointer` | ctx, stack, packet, shared |
+| `singleton_ptr` | Pointers to unique memory regions (ctx, stack, packet) |
+| `mem` | packet, stack, shared (memory that can be read/written) |
+| `mem_or_num` | number, stack, packet, shared |
+| `ptr_or_num` | number, ctx, stack, packet, shared (excluding map FD types) |
+
+### Common Assertions
+
+| Assertion | What It Checks |
+|-----------|----------------|
+| `valid_access(reg.offset, width=N) for read/write` | Memory access is within bounds |
+| `r<N>.type in {types}` | Register has one of the listed types |
+| `r<N>.type == number` | Register is a number (not a pointer) |
+| `r<N> != 0` | Register is non-zero (for division) |
+| `pc[N] < 100000` | Loop counter is within limit |
+| `within(reg:key_size(map))` | Map key access is valid |
+
+### Access Bounds Messages
+
+| Message | Meaning |
+|---------|---------|
+| `Lower bound must be at least 0` | Offset is negative when it shouldn't be |
+| `Upper bound must be at most X` | Access extends past end of region |
+| `Lower bound must be at least meta_offset` | Packet access before metadata start |
+| `Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE` | Stack underflow |
+| `Stack content is not numeric` | Reading non-numeric data from stack |
+| `Possible null access` | Pointer might be NULL |
+| `Nonzero context offset` | Context pointer was modified before passing to helper |
+
+---
+
+## 4. Common Failure Patterns
+
+### 4.1 Uninitialized Register Use
+
+**Symptom**: `Invalid type (r<N>.type in {number, ctx, stack, packet, shared})`
+
+**Cause**: Using a register before it has been assigned a value.
+
+**Example**:
+
+```text
+Pre-invariant:[r0.type=number, r0.svalue=1]
+   0: r0 += r3
+Error: 0: Invalid type (r3.type in {number, ctx, stack, packet, shared})
+```
+
+**Fix**: Initialize the register before use, or ensure it's passed as a parameter.
+
+---
+
+### 4.2 Unbounded Packet Access
+
+**Symptom**: `Upper bound must be at most packet_size (valid_access(r<N>.offset, width=W) for read/write)`
+
+**Cause**: Reading/writing packet data without first checking the bounds.
+
+**Example**:
+
+```text
+Pre-invariant:[packet_size=[0, 65534], r1.type=packet, r1.packet_offset=0]
+   0: r4 = *(u64 *)(r1 + 0)
+Error: 0: Upper bound must be at most packet_size
+```
+
+**Fix**: Add a bounds check before the access:
+
+```c
+if (data + sizeof(__u64) > data_end) return XDP_DROP;
+```
+
+---
+
+### 4.3 Stack Out-of-Bounds Access
+
+**Symptom**: `Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE`
+
+**Cause**: Accessing stack memory beyond the allocated frame.
+
+**Example**:
+
+```text
+Pre-invariant:[r10.type=stack, r10.stack_offset=1024]
+   0: *(u8 *)(r10 - 513) = 0
+Error: 0: Lower bound must be at least r10.stack_offset - EBPF_SUBPROGRAM_STACK_SIZE
+```
+
+**Fix**: Keep stack accesses within -512 to -1 of r10, or reduce local variable size.
+
+---
+
+### 4.4 Null Pointer After Map Lookup
+
+**Symptom**: `Possible null access (valid_access(...) for read/write)`
+
+**Cause**: Using a map lookup result without checking for NULL.
+
+**Example**:
+
+```c
+value = bpf_map_lookup_elem(&my_map, &key);
+*value = 42;  // Error: value might be NULL
+```
+
+**Fix**: Check the return value:
+
+```c
+value = bpf_map_lookup_elem(&my_map, &key);
+if (value) {
+    *value = 42;
+}
+```
+
+---
+
+### 4.5 Type Mismatch (Number as Pointer)
+
+**Symptom**: `Only pointers can be dereferenced (valid_access(...))`
+
+**Cause**: Trying to dereference a register that contains a number instead of a pointer.
+
+**Example**:
+
+```text
+Pre-invariant:[r1.type=number, r1.svalue=42]
+   0: r2 = *(u64 *)(r1 + 0)
+Error: 0: Only pointers can be dereferenced
+```
+
+**Fix**: Ensure the register contains a valid pointer type before dereferencing.
+
+---
+
+### 4.6 Type Mismatch
+
+**Symptom**: Type mismatch errors such as `Only numbers can be added to pointers`, `Only pointers can be dereferenced`, `Invalid type (rN.type == ...)`, or `Invalid type for operation`.
+
+**Cause**: Using a register with the wrong abstract type for a given operation—for example, adding a pointer to a pointer, dereferencing a number, passing a scalar where a pointer is expected, or using the wrong pointer subtype (e.g., `map_fd` where `map_fd_programs` is required for `bpf_tail_call`).
+
+**Fix**: Check the pre-invariant types of all registers involved in the failing instruction and ensure they match the verifier's expectations (e.g., addends are numbers, dereferenced values are pointers, helper arguments have the required pointer/number types).
+
+---
+
+### 4.7 Infinite Loop / Termination Failure
+
+**Symptom**: `Loop counter is too large (pc[N] < 100000)`
+
+**Cause**: The verifier cannot prove the loop terminates within the iteration limit.
+
+**Example**:
+
+```text
+Pre-invariant:[]
+   0: r0 = 0
+   1: if r0 < 1 goto <start>
+Error: 0 (counter): Loop counter is too large (pc[0] < 100000)
+```
+
+**Causes**:
+- No increment to the loop variable
+- Infinite loop by design (always branches back)
+- Bound check uses wrong comparison (e.g., `!=` instead of `<`)
+
+**Fix**: Ensure loop has a clear termination condition with a bounded counter.
+
+---
+
+### 4.8 Division by Zero
+
+**Symptom**: `Possible division by zero (r<N> != 0)`
+
+**Cause**: The divisor register might be zero.
+
+**Fix**: Add an explicit check before division:
+
+```c
+if (divisor != 0) {
+    result = dividend / divisor;
+}
+```
+
+---
+
+### 4.9 Map Key/Value Size Mismatch
+
+**Symptom**: `Illegal map update with a non-numerical value` or `Map key size is not singleton`
+
+**Cause**: The pointer passed to map helper doesn't point to enough numeric bytes, or the key/value size doesn't match the map definition.
+
+**Variant - Pointer Exposure**: If `s[N...M].type=ctx` (or other pointer type) appears in the stack range being used as a map value, the code is attempting to store a pointer into a map. This is a security violation—maps can only store numeric data.
+
+**Fix**: Ensure the stack buffer used for key/value is properly sized and initialized with numeric data. Never store pointers in maps.
+
+---
+
+### 4.10 Context Field Bounds Violation
+
+**Symptom**: `Upper bound must be at most <size>` for context access, or `Nonzero context offset (r<N>.ctx_offset == 0)`
+
+**Cause**: Reading past the end of the context structure, or passing a modified context pointer to a helper that requires the original.
+
+**Example**: XDP context is 20 bytes, accessing at offset 24 fails. Or adding an offset to the context pointer before passing it to a helper like `bpf_sock_map_update`.
+
+**Fix**: Only access defined fields within the context structure. Pass unmodified context pointers to helpers that require `ctx_offset == 0`.
+
+---
+
+### 4.11 Lost Correlations in Computed Branches (Verifier Limitation)
+
+**Symptom**: Access fails bounds check (e.g., `Upper bound must be at most packet_size`) even though a branch condition *should* guarantee safety.
+
+**Red Flags**:
+- Branch condition uses a register with a narrow computed range (e.g., `r3.svalue=[-22, 0]`)
+- The offset register has a wide range that wasn't narrowed by the branch (e.g., `r4.packet_offset=[14, 74]`)
+- Code appears to have a bounds check, but via an intermediate variable rather than direct pointer comparison
+
+**Cause**: The verifier's abstract domain (difference-bound matrices) cannot track implications through intermediate computations. If code computes `r3 = (ptr + N) - data_end`, then `r3 <= 0` *implies* the access is safe—but this implication is not propagated back to narrow the pointer's offset range.
+
+**Diagnosis**: This is a **verifier limitation**, not necessarily a code bug. The code may be correct, but the verifier cannot prove it.
+
+**Fixes** (workarounds to help the verifier):
+1. **Use direct pointer comparisons**: `if (ptr + N > data_end)` instead of computing into a temporary variable
+2. **Duplicate the bounds check** closer to the access point so the verifier sees it directly
+3. **Restructure control flow** so the safety implication is explicit in the branch structure rather than computed
+
+**Example**: Instead of:
+
+```c
+int diff = (data + 8) - data_end;
+if (diff > 0) return XDP_DROP;
+val = *(u64 *)data;  // Verifier may not see that diff <= 0 implies safety
+```
+
+Use:
+
+```c
+if (data + 8 > data_end) return XDP_DROP;
+val = *(u64 *)data;  // Verifier directly tracks the pointer comparison
+```
+
+---
+
+### 4.12 Stale Pointer After Reallocation
+
+**Symptom**: `Invalid type (rN.type in {ctx, stack, packet, shared})` after a helper call that may resize the packet buffer.
+
+**Cause**: A register held a `packet` pointer before a helper call (e.g., `bpf_xdp_adjust_head`, `bpf_skb_change_head`) that can reallocate the packet buffer. After the call, all previously-derived packet pointers are invalidated by the verifier because the underlying memory may have moved.
+
+**Fix**: Re-derive packet pointers from `ctx->data` / `ctx->data_end` after any helper call that may resize the packet buffer. Do not cache packet pointers across such calls.
+
+---
+
+## 5. LLM Reasoning Protocol
+
+When diagnosing a Prevail verification failure:
+
+### Step 1: Identify the Error
+
+Look for lines matching the pattern `<pc>: <message> (<assertion>)`. Note:
+- The program counter (pc) where the error occurs
+- The assertion type (e.g., `valid_access`, `type in {...}`, etc.)
+- The specific constraint that failed
+
+### Step 2: Locate the Context
+
+Find the pre-invariant just before the failing instruction. This shows the abstract state at that point.
+
+### Step 3: Trace the Register/Variable
+
+For the register(s) mentioned in the error:
+1. Check its type in the pre-invariant
+2. Check its value/offset constraints
+3. Look for missing constraints (e.g., no `packet_size` bound)
+
+### Step 4: Identify Missing Constraints
+
+Common missing constraints:
+- **For packet access**: `packet_size >= access_end` relationship is missing
+- **For shared access**: `r<N>.svalue > 0` (null check) is missing
+- **For stack access**: `stack_numeric_size` is too small
+- **For loops**: No counter increment or wrong comparison
+
+### Step 5: Trace Backwards
+
+If the pre-invariant seems correct, trace backwards to find where:
+- A required constraint was lost (widening in loops)
+- A branch condition wasn't captured
+- An initialization was skipped
+
+### Step 6: Formulate the Fix
+
+Typical fixes:
+- **Add bounds check** before memory access
+- **Add null check** after map lookup
+- **Initialize registers** before use
+- **Add loop bound** for termination
+- **Cast/narrow types** appropriately
+
+### Red Flags to Watch For
+
+| Pattern | Likely Issue |
+|---------|--------------|
+| `r<N>.type` missing from invariant | Uninitialized register |
+| `packet_size=[0, X]` without offset constraint | Missing bounds check |
+| `pc[N]=[1, +oo]` | Possible infinite loop |
+| `shared_region_size` not constrained | Map value size unknown |
+| Type is `number` but being dereferenced | Wrong register or missing assignment |
+| Branch on computed value + wide offset range persists | Lost correlation (verifier limitation, see 4.11) |
+
+---
+
+## 6. Extracting Additional Information
+
+When analyzing failures, you may need more context. Here's how to request it:
+
+### Verbose Output
+
+Run with `-v` flag for verbose output showing invariants at each step:
+
+```bash
+./bin/run_yaml test-data/<file>.yaml "<test name>" -v
+```
+
+### Full Program Listing
+
+Request the full disassembly to see surrounding instructions:
+
+```bash
+./bin/check <elf-file> <section> --asm <disasm-file>
+```
+
+### Specific Invariant
+
+Ask the user to share:
+1. The complete pre-invariant at the failing instruction
+2. The 3-5 instructions leading up to the failure
+3. Any branch conditions in the path
+
+### Map/Context Definitions
+
+For map-related errors, request:
+- Map type (array, hash, etc.)
+- Key size and value size
+- Context structure definition
+
+---
+
+## 7. Version Information
+
+- **Prevail Build Identifier**: From the repository root, run `git describe --tags --always --dirty` (or `git rev-parse HEAD`) to record the verifier build/commit.
+- **Document Version**: 1.0
+- **Last Updated**: 2026-02-10
+
+---
+
+## Appendix A: Quick Reference
+
+### Register Conventions
+
+| Register | Convention |
+|----------|------------|
+| r0 | Return value from helpers; final program return |
+| r1-r5 | Function arguments (caller-saved) |
+| r6-r9 | Callee-saved |
+| r10 | Read-only stack frame pointer |
+
+### Stack Layout
+
+- Main program: offsets 0-511 (accessed as r10-1 through r10-512)
+- Subprograms: additional 512 bytes per call depth
+- Total: up to 4KB (8 frames × 512 bytes)
+
+### Common Helper Patterns
+
+```c
+// Map lookup - always check for NULL
+void *value = bpf_map_lookup_elem(&map, &key);
+if (!value) return 0;
+
+// Packet access - always check bounds
+if (data + sizeof(struct hdr) > data_end) return XDP_DROP;
+
+// Division - always check divisor
+if (divisor == 0) return 0;
+result = dividend / divisor;
+```
+
+---
+
+## Appendix B: Extended Context for Advanced Diagnosis
+
+### Path-Insensitive Semantics
+
+Prevail uses a single abstract state per program point. All control-flow paths merge into this state.
+
+**Key Properties:**
+- No path-sensitive refinement
+- Correlated conditions are not preserved
+- Pointer and numeric constraints collapse at joins
+- Loop bodies merge with their own entry state
+
+**Example: Correlated Branch Collapse**
+
+```c
+if (x < 10) {
+    y = x + 1;
+}
+if (y < 11) {
+    // Linux: safe
+    // Prevail: y = [-inf, +inf]
+}
+```
+
+After the first if, Prevail merges the "taken" and "not taken" paths:
+- y is either x+1 or uninitialized
+- The join produces y = unknown
+
+### Widening and Narrowing Behavior
+
+Prevail applies widening to ensure termination of abstract interpretation.
+
+**When Widening Occurs:**
+- At loop headers
+- When intervals grow across iterations
+- When pointer offsets cannot be proven stable
+
+**Effects:**
+- Loop counters lose precision
+- Pointer bounds become unbounded
+- Relational constraints disappear
+
+**Example:**
+```c
+for (i = 0; i < n; i++) {
+    ptr = base + i;
+}
+```
+After widening:
+- i = [-inf, +inf]
+- ptr = base + unknown
+
+### Pointer Provenance Rules
+
+Prevail tracks pointer provenance strictly:
+
+- Pointers belong to regions: stack, map value, packet, shared memory
+- Pointer-to-pointer storage collapses provenance
+- Arithmetic must stay within the same region
+- Subtracting pointers yields a number and destroys provenance
+
+**Example: Storing a Stack Pointer**
+
+```c
+*(u64 *)buf = (u64)stack_ptr;
+```
+
+After this:
+- The stored value is a number
+- Reloading it yields a number, not a pointer
+- Any use as a pointer fails
+
+### Subprogram and Call-Frame Semantics
+
+**Register Rules:**
+- r1–r5: arguments
+- r0: return value
+- r6–r9: callee-saved
+- r10: frame pointer (read-only)
+
+**Stack Behavior:**
+- Each subprogram has its own stack frame
+- Stack offsets are validated per frame
+- Returning merges the callee's exit state into the caller
+
+**Common Failure:**
+Using r6 as a pointer without reinitializing after a call.
+
+### Helper Function Contracts
+
+Prevail enforces helper contracts strictly.
+
+**Contract Components:**
+- Argument types (pointer, scalar, map handle)
+- Required bounds
+- Return type (pointer, scalar, nullable pointer)
+- Side effects (packet size changes, map value lifetime)
+
+**Example: bpf_map_lookup_elem**
+- r1: map handle (scalar)
+- r2: pointer to key (stack or packet)
+- Returns:
+  - pointer to map value (shared region), or
+  - NULL
+
+LLMs must check:
+- key pointer validity
+- key size
+- map value pointer provenance
+
+### Differences Between Linux and Prevail
+
+Prevail is intentionally more conservative.
+
+| Feature | Linux Verifier | Prevail |
+|--------|----------------|---------|
+| Path sensitivity | Yes | No |
+| Relational constraints | Some | Yes (DBM), but lost at joins/widening |
+| Loop unrolling | Aggressive | None |
+| Pointer tracking | Fine-grained | Region-based |
+| Stack modeling | Per-path | Merged |
+
+LLMs must not assume Linux-accepted code will pass Prevail.
+
+### Canonical Fix Patterns
+
+**Loop Fixes:**
+- Use fixed upper bounds
+- Hoist bounds checks outside loops
+- Avoid induction variables tied to pointer offsets
+
+**Pointer Fixes:**
+- Avoid storing pointers in memory
+- Recompute pointers from base + constant offsets
+- Use helper-returned pointers directly
+
+**Map Access Fixes:**
+- Validate key pointers explicitly
+- Avoid pointer arithmetic on map values
+- Copy map values to stack if needed
+
+---
+
+## Appendix C: Worked Diagnosis Example
+
+**Scenario**: Unbounded packet read fails verification.
+
+### The Error
+
+```text
+0: Upper bound must be at most packet_size (valid_access(r1.offset, width=8) for read)
+```
+
+### The Log
+
+```text
+Pre-invariant:[
+    meta_offset=0,
+    packet_size=[0, 65534],
+    r1.packet_offset=0, r1.type=packet, r1.svalue=[4098, 2147418112]]
+   0: r4 = *(u64 *)(r1 + 0)
+```
+
+### Diagnosis
+
+1. **Error location**: PC 0, reading 8 bytes from `r1`
+2. **Pre-invariant shows**: `r1.packet_offset=0`, `packet_size=[0, 65534]`
+3. **The problem**: Access requires `0 + 8 <= packet_size`, but `packet_size` could be 0
+4. **Missing constraint**: No bounds check establishes `packet_size >= 8`
+
+### Fix
+
+Add bounds check before access:
+
+```c
+if (data + 8 > data_end) return XDP_DROP;
+// Now packet_size >= 8 is established
+value = *(u64 *)data;
+```

--- a/test-data/llm-context-tests.md
+++ b/test-data/llm-context-tests.md
@@ -1,0 +1,517 @@
+# LLM Context Document Test Cases
+
+This file contains test cases for validating that `docs/llm-context.md` enables accurate diagnosis of verification failures.
+
+## Prerequisites
+
+The test samples are in `ebpf-samples/build/`. These are built from source files in `ebpf-samples/src/` by configuring and building the `ebpf-samples` sub-project explicitly:
+
+```bash
+cmake -S ebpf-samples -B ebpf-samples/cmake-build -DCMAKE_BUILD_TYPE=Release
+cmake --build ebpf-samples/cmake-build
+```
+
+Other samples are pre-built in `ebpf-samples/cilium/`, `ebpf-samples/prototype-kernel/`, `ebpf-samples/linux/`, and `ebpf-samples/cilium-core/`.
+
+## How to Test
+
+In a GitHub Copilot CLI session:
+
+```text
+Using docs/llm-context.md, run ./bin/check <sample> <section> -v and diagnose the failure.
+```
+
+The LLM should:
+1. Identify the correct failure pattern from the document
+2. Explain the root cause by reading the pre-invariant
+3. Suggest the correct fix
+
+## Automated Regression Prompt
+
+The following prompt can be used in a Copilot CLI session to execute all test cases automatically:
+
+```text
+Read docs/llm-context.md for diagnostic patterns. Then for each test case in
+test-data/llm-context-tests.md, run the specified command and diagnose the failure.
+
+For each test case:
+1. Run the command shown
+2. Identify the §4.X pattern from llm-context.md that matches the error
+3. Read the pre-invariant at the failing label to confirm the root cause
+4. Compare your diagnosis against the expected pattern and key invariant
+
+Report results as a table:
+| Test | Expected Pattern | Actual Pattern | Key Invariant Found | PASS/FAIL |
+
+A test PASSES when:
+- The correct §4.X pattern is identified
+- The key invariant from the expected values is present in the output
+- The root cause explanation is consistent with the expected fix
+
+Skip any test marked as SLOW unless specifically requested.
+```
+
+## Test Cases — Small Programs
+
+### Test 1: Null Pointer After Map Lookup
+
+```bash
+./bin/check ebpf-samples/build/nullmapref.o test -v
+```
+**Expected error**: `Possible null access (valid_access(r0.offset, width=4) for write)`
+**Pattern**: 4.4 - Null Pointer After Map Lookup
+**Key invariant**: `r0.svalue=[0, 2147418112]` - lower bound of 0 means NULL is possible
+**Fix**: Add null check after `bpf_map_lookup_elem`
+
+---
+
+### Test 2: Unbounded Packet Access
+```bash
+./bin/check ebpf-samples/build/packet_overflow.o xdp -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r2.offset, width=4) for read)`
+**Pattern**: 4.2 - Unbounded Packet Access
+**Key invariant**: `packet_size=0` - no bounds check established minimum packet size
+**Fix**: Add `if (data + N > data_end)` check before access
+
+---
+
+### Test 3: Uninitialized Stack Memory
+```bash
+./bin/check ebpf-samples/build/ringbuf_uninit.o .text -v
+```
+**Expected error**: `Stack content is not numeric (valid_access(r2.offset, width=r3) for read)`
+**Pattern**: 4.9 variant - stack buffer not initialized with numeric data before helper call
+**Key invariant**: `Stack: Numbers -> {}` - no stack bytes marked as numeric
+**Fix**: Initialize stack buffer before passing to helper
+
+---
+
+### Test 4: Pointer Exposure to Map
+```bash
+./bin/check ebpf-samples/build/exposeptr.o .text -v
+```
+**Expected error**: `Illegal map update with a non-numerical value [4088-4096) (within(r3:value_size(r1)))`
+**Pattern**: 4.9 - Map Key/Value Size Mismatch (non-numeric variant)
+**Key invariant**: `s[4088...4095].type=ctx` - context pointer stored on stack, passed as map value
+**Fix**: Store numeric data only in maps (security: prevents kernel address leaks)
+
+---
+
+### Test 5: Nonzero Context Offset
+```bash
+./bin/check ebpf-samples/build/ctxoffset.o sockops -v
+```
+**Expected error**: `Nonzero context offset (r1.ctx_offset == 0)`
+**Pattern**: 4.10 - Context Field Bounds Violation (ctx_offset variant)
+**Key invariant**: `r1.ctx_offset=8` - context pointer was modified before helper call
+**Fix**: Pass original unmodified context pointer to helpers
+
+---
+
+### Test 6: Map Value Overrun
+```bash
+./bin/check ebpf-samples/build/mapvalue-overrun.o .text -v
+```
+**Expected error**: `Upper bound must be at most r1.shared_region_size (valid_access(r1.offset, width=8) for read)`
+**Pattern**: Similar to 4.2 but for shared memory
+**Key invariant**: `r1.shared_region_size=4` - map value is 4 bytes, but reading 8
+**Fix**: Match read width to map value size, or increase map value size
+
+---
+
+### Test 7: Pointer Arithmetic with Non-Number
+```bash
+./bin/check ebpf-samples/build/ptr_arith.o xdp -v
+```
+**Expected error**: `Invalid type (r<N>.type == number)`
+**Pattern**: 4.6 - Pointer Arithmetic with Non-Number
+**Key invariant**: Register used in arithmetic has `type=packet` instead of `type=number`
+**Fix**: Only add/subtract numeric values to/from pointers
+
+---
+
+### Test 8: Division by Zero
+```bash
+./bin/check ebpf-samples/build/divzero.o test -v --no-division-by-zero
+```
+**Expected error**: `Possible division by zero`
+**Pattern**: 4.8 - Division by Zero
+**Key invariant**: Divisor register has `svalue=[0, ...]` - lower bound includes 0
+**Fix**: Add check `if (divisor != 0)` before division
+**Note**: Requires `--no-division-by-zero` flag because the verifier allows division by zero by default (`--allow-division-by-zero`); the negated flag enables the check
+
+---
+
+### Test 9: Infinite Loop (Unbounded)
+```bash
+./bin/check ebpf-samples/build/infinite_loop.o test -v --termination
+```
+**Expected error**: `Could not prove termination` or loop counter shows `[1, +oo]`
+**Pattern**: 4.7 - Infinite Loop / Termination Failure
+**Key invariant**: Loop bound comes from map value with unbounded range `[0, UINT32_MAX]`
+**Fix**: Use compile-time constant bounds or restructure loop
+**Note**: Requires `--termination` flag (termination checking is disabled by default)
+
+---
+
+### Test 10: Bounded Loop (Compiler Transformation)
+```bash
+./bin/check ebpf-samples/build/bounded_loop.o test -v --termination
+```
+**Expected error**: `Could not prove termination`
+**Pattern**: 4.7 - Infinite Loop / Termination Failure (compiler transformation variant)
+**Key invariant**: Clang transforms `i < 1000` to `i != 1000`; verifier can't prove equality will be reached
+**Fix**: This is a verifier limitation; the loop is actually bounded but unprovable
+**Note**: Requires `--termination` flag (termination checking is disabled by default)
+
+---
+
+### Test 11: Lost Correlations in Computed Branches
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/20 -v
+```
+**Expected error**: `Upper bound must be at most packet_size`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Branch on computed value (e.g., `r4.svalue=[-22, 0]`) but packet offset range remains wide
+**Fix**: Use direct pointer comparisons instead of computed intermediates (verifier limitation)
+
+---
+
+### Test 12: Bad Map Pointer Type
+```bash
+./bin/check ebpf-samples/build/badmapptr.o test -v
+```
+**Expected error**: `Invalid type (r1.type in {number, ctx, stack, packet, shared})`
+**Pattern**: 4.6 - Type Mismatch (using map_fd where a pointer is expected)
+**Key invariant**: `r1.type=map_fd` — a map file descriptor was passed where the helper expects a memory pointer
+**Fix**: Pass a pointer to the map value (from `bpf_map_lookup_elem`), not the map fd itself
+
+---
+
+### Test 13: Bad Helper Call (Stack Overflow)
+```bash
+./bin/check ebpf-samples/build/badhelpercall.o .text -v
+```
+**Expected error**: `Upper bound must be at most EBPF_TOTAL_STACK_SIZE (valid_access(r1.offset, width=r2) for write)`
+**Pattern**: 4.3 - Stack Out-of-Bounds Access
+**Key invariant**: `r1.stack_offset=4095` with `r2.svalue=20` — writing 20 bytes at stack offset 4095 exceeds EBPF_TOTAL_STACK_SIZE (4096)
+**Fix**: Ensure stack pointer + access width stays within the current 512-byte stack frame (absolute offsets 3584–4096 for the main frame)
+
+---
+
+### Test 14: Dependent Packet Read (Lost Correlation)
+```bash
+./bin/check ebpf-samples/build/dependent_read.o xdp -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r1.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: At the failing label, `packet_size=1` but reading 4 bytes. The bounds check path sets `r5=1` with `packet_size=4`, but the join with the non-checked path (`r5=0`, `packet_size=0`) weakens `packet_size` to 1. The `assume r5 != 0` guard does not recover the correlation.
+**Fix**: Use direct `if (data + 4 > data_end)` check immediately before the read (verifier limitation with indirect guards)
+
+---
+
+### Test 15: Pointer Exposure to Map (Key Variant)
+```bash
+./bin/check ebpf-samples/build/exposeptr2.o .text -v
+```
+**Expected error**: `Illegal map update with a non-numerical value [4088-4096) (within(r2:key_size(r1)))`
+**Pattern**: 4.9 - Map Key/Value Size Mismatch (non-numeric variant)
+**Key invariant**: `s[4088...4095].type=ctx` — context pointer stored on stack, passed as map key
+**Fix**: Store only numeric data in map keys (security: prevents kernel address leaks)
+
+---
+
+### Test 16: Stale Packet Pointer After Reallocation
+```bash
+./bin/check ebpf-samples/build/packet_reallocate.o socket_filter -v
+```
+**Expected error**: `Invalid type (r7.type in {ctx, stack, packet, shared})`
+**Pattern**: 4.12 - Stale Pointer After Reallocation
+**Key invariant**: `r7.type=packet` — r7 held a packet pointer before a helper call that may reallocate the packet buffer; after the call, the pointer is invalidated
+**Fix**: Re-derive packet pointers from `ctx->data` / `ctx->data_end` after any helper call that may resize the packet
+
+---
+
+### Test 17: Wrong Map Type for Tail Call
+```bash
+./bin/check ebpf-samples/build/tail_call_bad.o xdp_prog -v
+```
+**Expected error**: `Invalid type (r2.type == map_fd_programs)`
+**Pattern**: 4.6 - Type Mismatch
+**Key invariant**: `r2.type=map_fd` but `bpf_tail_call` requires `r2.type=map_fd_programs` — a regular map was passed instead of a program array map
+**Fix**: Use a `BPF_MAP_TYPE_PROG_ARRAY` map for tail calls
+
+---
+
+## Test Cases — Large Programs
+
+### Test 18: Map Lookup After Conditional (xdp_ddos, xdp_prog)
+```bash
+./bin/check ebpf-samples/prototype-kernel/xdp_ddos01_blacklist_kern.o xdp_prog -v
+```
+**Expected error**: `Invalid type (r1.type == map_fd)`
+**Pattern**: 4.11 - Lost Correlations (type domain)
+**Key invariant**: `r1.type in {map_fd, number}` — after a conditional, one path sets r1 to a map_fd and the other leaves it as number; the join produces a union type that fails the `map_fd` assertion
+**Fix**: Restructure to ensure `bpf_map_lookup_elem` is only called when r1 is definitely a map_fd (move the call inside the branch)
+
+---
+
+### Test 19: Pointer Arithmetic Type Error (xdp_ddos, .text)
+```bash
+./bin/check ebpf-samples/prototype-kernel/xdp_ddos01_blacklist_kern.o .text -v
+```
+**Expected error**: `Invalid type (r2.type == number)`
+**Pattern**: 4.6 - Pointer Arithmetic with Non-Number
+**Key invariant**: r2 has a non-number type when used in arithmetic — the instruction expects a numeric operand
+**Fix**: Ensure the register holds a numeric value before arithmetic operations
+
+---
+
+### Test 20: Map-in-Map Lookup Type
+```bash
+./bin/check ebpf-samples/linux/test_map_in_map_kern.o "kprobe/sys_connect" -v
+```
+**Expected error**: `Invalid type (r1.type == map_fd)`
+**Pattern**: 4.11 - Lost Correlations (inner map lookup)
+**Key invariant**: `r1.type=number` or `r1.type=shared` — after `bpf_map_lookup_elem` on an outer map, the result should be used as a map_fd for the inner lookup, but the verifier tracks it as number/shared
+**Fix**: This is a verifier limitation with map-in-map support; the verifier does not currently track inner map fd types through lookups
+
+---
+
+### Test 21: Non-Numerical Map Key (bpf_sock)
+```bash
+./bin/check ebpf-samples/cilium-core/bpf_sock.o "cgroup/recvmsg6" -v
+```
+**Expected error**: `Illegal map update with a non-numerical value [4048-4072) (within(r2:key_size(r1)))`
+**Pattern**: 4.9 - Map Key/Value Size Mismatch (non-numeric variant)
+**Key invariant**: Stack region `[4048-4072)` contains bytes not proven numeric — some bytes in the map key buffer were not initialized with numeric values
+**Fix**: Initialize all bytes of the map key structure before passing to map helper
+
+---
+
+### Test 22: Unbounded Packet Access (bpf_xdp core)
+```bash
+./bin/check ebpf-samples/cilium-core/bpf_xdp.o "xdp/entry" -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r5.offset, width=1) for read)`
+**Pattern**: 4.11 - Lost Correlations
+**Key invariant**: `packet_size=34` but `r5.packet_offset=34` — reading 1 byte at offset 34 needs `packet_size ≥ 35`; a bounds check on a different path established `packet_size=35` but the join lost it
+**Fix**: Restructure bounds check to directly guard the failing access path
+
+---
+
+### Test 23: Cilium DSR — Packet Write (2/7)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/7 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: `packet_size` is too small for the packet offset — bounds check result communicated through computed value, correlation lost at join
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 24: Cilium DSR — Packet Write (2/10)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/10 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size at the access point
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 25: Cilium DSR — Packet Write (2/17)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/17 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size at the access point
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 26: Cilium DSR — Packet Read (2/18)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/18 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size at the access point
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 27: Cilium DSR — Packet Write (2/21)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/21 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=2) for write)`
+**Pattern**: 4.2 - Unbounded Packet Access
+**Key invariant**: `packet_size=12` but `r4.packet_offset=12` — writing 2 bytes at offset 12 needs `packet_size ≥ 14`
+**Fix**: Add bounds check `if (data + 14 > data_end)` before the write
+
+---
+
+### Test 28: Cilium SNAT — Packet Read (2/7)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/7 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size — same pattern as DSR 2/7
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 29: Cilium SNAT — Packet Read (2/10)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/10 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size — same pattern as DSR 2/10
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 30: Cilium SNAT — Packet Read (2/17)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/17 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size — same pattern as DSR 2/17
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 31: Cilium SNAT — Packet Read (2/18)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/18 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size — same pattern as DSR 2/18
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+## Test Cases — Large Programs (SLOW)
+
+These tests take significantly longer to run. Skip unless specifically requested.
+
+### Test 32: Cilium DSR — Packet Access (2/15) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/15 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r5.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 33: Cilium DSR — Type Error (2/16) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/16 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r3.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 34: Cilium DSR — Packet Access (2/19) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/19 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 35: Cilium DSR — Type Error (2/24) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_dsr_linux.o 2/24 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r5.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 36: Cilium SNAT — Packet Access (2/15) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/15 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r5.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 37: Cilium SNAT — Type Error (2/16) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/16 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r3.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 38: Cilium SNAT — Packet Access (2/19) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/19 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r4.offset, width=4) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+### Test 39: Cilium SNAT — Type Error (2/24) (SLOW)
+```bash
+./bin/check ebpf-samples/cilium/bpf_xdp_snat_linux.o 2/24 -v
+```
+**Expected error**: `Upper bound must be at most packet_size (valid_access(r5.offset, width=2) for read)`
+**Pattern**: 4.11 - Lost Correlations in Computed Branches
+**Key invariant**: Packet offset exceeds proven packet_size
+**Fix**: Verifier limitation with indirect bounds communication
+
+---
+
+## Results Summary
+
+All 39 test cases should produce the expected errors when run against a Prevail build.
+Tests 1–31 run in under a few seconds each. Tests 32–39 (SLOW) may take significantly longer.
+
+When validated with an LLM using `docs/llm-context.md`, the LLM should correctly identify the §4.X pattern for each test case.
+
+**Prevail build**: Run `git describe --tags --always --dirty` from the repository root to record the build used for validation.
+
+## Pattern Coverage
+
+| Pattern | Tests |
+|---------|-------|
+| 4.2 - Unbounded Packet Access | 2, 27 |
+| 4.3 - Stack Out-of-Bounds Access | 13 |
+| 4.4 - Null Pointer After Map Lookup | 1 |
+| 4.6 - Type Mismatch | 7, 12, 17, 19 |
+| 4.7 - Infinite Loop / Termination | 9, 10 |
+| 4.8 - Division by Zero | 8 |
+| 4.9 - Map Key/Value Non-Numeric | 3, 4, 15, 21 |
+| 4.10 - Context Field Bounds Violation | 5 |
+| 4.11 - Lost Correlations | 6, 11, 14, 18, 20, 22–26, 28–39 |
+| 4.12 - Stale Pointer After Reallocation | 16 |

--- a/test-data/llm-context-tests.md
+++ b/test-data/llm-context-tests.md
@@ -81,7 +81,7 @@ Skip any test marked as SLOW unless specifically requested.
 ./bin/check ebpf-samples/build/ringbuf_uninit.o .text -v
 ```
 **Expected error**: `Stack content is not numeric (valid_access(r2.offset, width=r3) for read)`
-**Pattern**: 4.9 variant - stack buffer not initialized with numeric data before helper call
+**Pattern**: 4.13 - Non-Numeric Stack Content
 **Key invariant**: `Stack: Numbers -> {}` - no stack bytes marked as numeric
 **Fix**: Initialize stack buffer before passing to helper
 
@@ -511,7 +511,8 @@ When validated with an LLM using `docs/llm-context.md`, the LLM should correctly
 | 4.6 - Type Mismatch | 7, 12, 17, 19 |
 | 4.7 - Infinite Loop / Termination | 9, 10 |
 | 4.8 - Division by Zero | 8 |
-| 4.9 - Map Key/Value Non-Numeric | 3, 4, 15, 21 |
+| 4.9 - Map Key/Value Non-Numeric | 4, 15, 21 |
+| 4.13 - Non-Numeric Stack Content | 3 |
 | 4.10 - Context Field Bounds Violation | 5 |
 | 4.11 - Lost Correlations | 6, 11, 14, 18, 20, 22–26, 28–39 |
 | 4.12 - Stale Pointer After Reallocation | 16 |


### PR DESCRIPTION
Implements issue #993: Create a Model-Ready Prevail Context Document for LLM-Assisted Diagnosis.

Adds docs/llm-context.md (~4k tokens) containing:
- Overview of Prevail verification approach
- Log format interpretation guide
- Glossary of log terms and assertions
- 10 common failure patterns with symptoms/fixes
- LLM reasoning protocol for diagnosis
- Worked example walkthrough

Adds test-data/llm-context-tests.md with 6 validated test cases:
- Null pointer after map lookup
- Unbounded packet access
- Uninitialized stack memory
- Pointer exposure to map
- Nonzero context offset
- Map value overrun

Updates docs/README.md with usage instructions for both GitHub Copilot CLI and manual LLM workflows.

Resolves: #995